### PR TITLE
Strategy alterations

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ python -m lukefi.metsi.app.metsi --help
 
 Input path, output path and optionally the control file path must be supplied as CLI positional arguments. All other
 parameters in commands below can also be set in the `control.yaml` file `app_configuration` block. Control file settings
-override program defaults (see app/app_io.py Mela2Configuration class). CLI arguments override the settings in the
+override program defaults (see app/app_io.py MetsiConfiguration class). CLI arguments override the settings in the
 control file.
 
 **At the time of writing this, there are no post-processing operations ready to be used. Post-processing

--- a/README.md
+++ b/README.md
@@ -4,11 +4,10 @@ Metsi forestry simulator is a Python based forest growth and maintenance operati
 Resources Institute Finland. It is a part of a software collection to eventually replace the older Fortran based MELA
 simulator program developed since the 1980s.
 
-The simulator is a stepwise branching state simulator operating upon forest state data. The state data is manipulated by
+The simulator is a branching state simulator operating upon forest state data. The state data is manipulated by
 **simulator operations**, which in turn rely upon **operation chains**. The branching model for simulator operations is
-declared in a human-readable YAML format or directly by functional declaration. This declaration is used to generate a *
-*step tree** describing the full branching possibilities for the simulation. Prepared **operation chains** are generated
-from the step tree and are run with the simulator engine.
+declared in a human-readable YAML format or directly by functional declaration. This declaration is used to generate a **simulation event tree** describing the full branching possibilities for the simulation. Prepared **operation chains** are generated
+from the event tree and are run with the simulator engine.
 
 ## Getting started
 
@@ -754,7 +753,7 @@ A run is declared in the YAML file `control.yaml`.
 4. List of `simulation_events`, where each object represents a single set of operations and a set of time points for
    those operations to be run.
     1. `time_points` is a list of integers which assign this set of operations to simulation time points
-    2. `generators` is a list of chained generator functions (see section on step generators)
+    2. `generators` is a list of chained generator functions (see section on simulation event generators)
         1. `sequence` a list of operations to be executed as a chain
         2. `alternatives` a list of operations which represent alternative branches
 5. Preprocessing operations can be passed as a list of strings under `preprocessing_operations`, and their (optional)
@@ -775,7 +774,7 @@ A run is declared in the YAML file `control.yaml`.
 8. Export is controlled in the `export` section of the file (TODO: structure is in works)
 
 The following example declares a simulation, which runs four event cycles at time points 0, 5, 10 and 15.
-Images below describe the simulation as a step tree, and further as the computation chains that are generated from the
+Images below describe the simulation as an event tree, and further as the computation chains that are generated from the
 tree.
 
 * At time point 0, `reporting` of the simulation state is done.
@@ -821,11 +820,12 @@ simulation_events:
           - reporting
 ```
 
-Step tree from declaration above
+Event tree from declaration above
 
-![Step tree](doc/drawio/20220221_sim-tree.drawio.png)
+![Event tree](doc/drawio/20220221_sim-tree.drawio.png)
 
-Operation chains from step tree above, as produced by the __full tree strategy__ (see below for partial tree strategy)
+Operation chains from event tree above, as produced by the **full** tree formation strategy. See below for the partial
+tree strategy.
 
 ![Operation chains](doc/drawio/20220221_sim-chains.drawio.png)
 
@@ -878,7 +878,8 @@ preprocessing_params:
 
 ## Simulator
 
-The three important concepts in the `sim` package are **operations**, **processor**, **step tree** and **generators**.
+The three important concepts in the `sim` package are **operations**, **processor**, **event tree** and
+**event generators**.
 
 ### Operation
 
@@ -904,28 +905,30 @@ follows:
 
 Processor functions are produced as lambda functions based on the `control.yaml` declaration.
 
-### The step tree
+### The event tree
 
-The step tree is a tree data structure where each individual node represents a prepared simulation processor. It is
-generated based on the `control.yaml` declaration. Unique operation chains are generated based on the step tree.
+The event tree is a tree data structure where each individual node represents a prepared simulation operation. It is
+generated based on the `control.yaml` declaration. Unique operation chains are generated based on the event tree for
+individual chain runs, or the event tree can be evaluated by depth-first walkthrough. This is controlled by the
+evaluation strategy.
 
-### Generators
+### Event generators
 
-`sequence` and `alternatives` are functions which produce `Step` instances for given input functions and as successors
-of previous `Step` instances. For the simulation purposes, these input functions are the prepared processors (see
-above), but the simulator implementation literally does not care what these functions are. Sequences are linear chains
-of steps. Alternatives are branching steps. Step instances are generated and bound to earlier steps (parents) as
-successors (children).
+`sequence` and `alternatives` are functions which produce `EventTree` instances for given input functions and as
+successors of previous `EventTree` instances. For the simulation purposes, these input functions are the prepared
+processors (see above), but the simulator implementation literally does not care what these functions are. Sequences are
+linear chains of event. Alternatives are branching events. EventTree instances are generated and bound to earlier
+EventTree leaf nodes as branches.
 
-The generators are chainable and nestable such that they can expand the step tree in formation based on the results of a
-previous generator's results. The `NestableGenerator` represents a tree structure for nested generator declarations. It
-is constructed from the `simulation_events` structure given from a configuration source. A `SimConfiguration` structure,
-likewise populated from a configuration source is used as a template for binding the created generator functions with
-prepared domain operation functions. The control source is an application's `control.yaml` file's dict structure or
-another compatible source.
+The generators are chainable and nestable such that they can expand the event tree in formation based on the results of
+a previous generator's results. The `NestableGenerator` represents a tree structure for nested generator declarations.
+It is constructed from the `simulation_events` structure given from a configuration source. A `SimConfiguration`
+structure, likewise populated from a configuration source is used as a template for binding the created generator
+functions with prepared domain operation functions. The control source is an application's `control.yaml` file's dict
+structure or another compatible source.
 
 `compose_nested` function executes the given `NestableGenerator` which in turn utilizes its prepared `sequence`
-and `alternatives` calls to build a complete simulation step tree.
+and `alternatives` calls to build a complete simulation event tree.
 
 ## The domain
 
@@ -952,9 +955,9 @@ not mutate the operation parameter `dict`
 
 `sim.runners` module has two functions of interest:
 
-* `evaluate_sequence` executes a prepared chain of functions (from the step tree), returning the final simulated stated
+* `evaluate_sequence` executes a prepared chain of functions (from the event tree), returning the final simulated stated
   or raising an execption upon any failure.
-* `run_chains_iteratively` is a simple iterator for given chain of prepared operations (from the step tree)
+* `run_chains_iteratively` is a simple iterator for given chain of prepared operations (from the event tree)
 
 Note that this package is a simple run-testing implementation. In the future we wish to expand upon this to allow for
 distributed run scenarios using Dask.
@@ -1082,10 +1085,10 @@ on the thinning operation. At time point 5, The partial tree strategy would then
 for `output 1`, i.e. the two chains on the left in the above diagram. This logic reduces the unnecessary computation the
 simulator has to make, compared to the full strategy, and this is true especially for large simulation trees.
 
-"Partial" in the strategy name refers to the fact that the strategy creates trees from only the nodes (`Step`s) in one
-time point at a time (i.e. partial trees/subtrees) and traverses those partial trees (with the same post-order traversal
-algorithm) to create partial (or sub-) chains of operations. __Therefore, the strategy can be thought to operate
-depth-first within time points, but breadth-first across time points.__
+"Partial" in the strategy name refers to the fact that the strategy creates trees from only the nodes (`EventTree`s) in
+one time point at a time (i.e. partial trees/subtrees) and traverses those partial trees (with the same post-order
+traversal algorithm) to create partial (or sub-) chains of operations. __Therefore, the strategy can be thought to
+operate depth-first within time points, but breadth-first across time points.__
 
 ## Notes for simulation creators
 

--- a/control.yaml
+++ b/control.yaml
@@ -5,7 +5,8 @@ app_configuration:
   #preprocessing_output_container: csv #options: pickle, json, csv, null, rsd (special case not usable as input container)
   #state_output_container: csv #options: pickle, json, csv, null
   #derived_data_output_container: pickle #options: pickle, json, null
-  strategy: partial
+  formation_strategy: partial
+  evaluation_strategy: depth
   run_modes: preprocess,simulate,postprocess,export
 
 run_constraints:

--- a/lukefi/metsi/app/app_io.py
+++ b/lukefi/metsi/app/app_io.py
@@ -21,7 +21,8 @@ class MetsiConfiguration(SimpleNamespace):
     state_output_container = None
     preprocessing_output_container = None
     derived_data_output_container = None
-    strategy = "partial"
+    formation_strategy = "partial"
+    evaluation_strategy = "depth"
     multiprocessing = False
     reference_trees = False  # ForestBuilder parameter
     strata_origin = "1"  # ForestBuilder parameter
@@ -75,6 +76,15 @@ def remove_nones(source: dict) -> dict:
 def generate_program_configuration(cli_args: argparse.Namespace, control_source: dict={}) -> MetsiConfiguration:
     """Generate a Mela2Configuration, overriding values with control file source, then with CLI arguments"""
     cli_source = remove_nones(cli_args.__dict__)
+
+    # DEPRECATED: Backwards compatiblity until next version
+    if control_source.get('strategy') is not None:
+        control_source['formation_strategy'] = control_source.get('strategy')
+        control_source.__delitem__('strategy')
+    if cli_source.get('strategy') is not None:
+        cli_source['formation_strategy'] = cli_source.get('strategy')
+        cli_source.__delitem__('strategy')
+
     merged = {**control_source, **cli_source}
     result = MetsiConfiguration(**merged)
     return result
@@ -104,7 +114,13 @@ def parse_cli_arguments(args: list[str]):
                         type=str)
     parser.add_argument('-s', '--strategy',
                         type=str,
-                        help='Simulation event tree formation strategy: \'full\' (default), \'partial\', \'skip\'')
+                        help='Simulation event tree formation strategy: \'full\', \'partial\' (default). DEPRECATION WARNING: migrate to using --formation-strategy')
+    parser.add_argument('-f', '--formation-strategy',
+                        type=str,
+                        help='Simulation event tree formation strategy: \'full\', \'partial\' (default)')
+    parser.add_argument('-e', '--evaluation-strategy',
+                        type=str,
+                        help='Simulation event tree evaluation strategy: \'depth\' (default), \'chains\'')
     parser.add_argument('--state-format',
                         choices=['fdm', 'vmi12', 'vmi13', 'forest_centre'],
                         type=str,

--- a/lukefi/metsi/app/app_io.py
+++ b/lukefi/metsi/app/app_io.py
@@ -11,7 +11,7 @@ class RunMode(Enum):
     EXPORT = "export"
 
 
-class Mela2Configuration(SimpleNamespace):
+class MetsiConfiguration(SimpleNamespace):
     input_path = None
     target_directory = None
     control_file = "control.yaml"
@@ -72,11 +72,11 @@ def remove_nones(source: dict) -> dict:
     return filtered
 
 
-def generate_program_configuration(cli_args: argparse.Namespace, control_source: dict={}) -> Mela2Configuration:
+def generate_program_configuration(cli_args: argparse.Namespace, control_source: dict={}) -> MetsiConfiguration:
     """Generate a Mela2Configuration, overriding values with control file source, then with CLI arguments"""
     cli_source = remove_nones(cli_args.__dict__)
     merged = {**control_source, **cli_source}
-    result = Mela2Configuration(**merged)
+    result = MetsiConfiguration(**merged)
     return result
 
 

--- a/lukefi/metsi/app/export.py
+++ b/lukefi/metsi/app/export.py
@@ -1,13 +1,13 @@
 from pathlib import Path
 
-from lukefi.metsi.app.app_io import Mela2Configuration
+from lukefi.metsi.app.app_io import MetsiConfiguration
 from lukefi.metsi.app.app_types import SimResults
 from lukefi.metsi.app.export_handlers.j import j_out, parse_j_config
 from lukefi.metsi.app.console_logging import print_logline
 from lukefi.metsi.app.export_handlers.rm_timber import rm_schedules_events_timber, rm_schedules_events_trees
 
 
-def export_files(config: Mela2Configuration, decl: list[dict], data: SimResults):
+def export_files(config: MetsiConfiguration, decl: list[dict], data: SimResults):
     output_handlers = []
     for export_module_declaration in decl:
         export_module = export_module_declaration.get("format", None)

--- a/lukefi/metsi/app/export_handlers/j.py
+++ b/lukefi/metsi/app/export_handlers/j.py
@@ -4,7 +4,7 @@ from functools import cache
 from pathlib import Path
 from typing import TypeVar, Generic, Any, Union, Iterator, IO
 
-from lukefi.metsi.app.app_io import Mela2Configuration
+from lukefi.metsi.app.app_io import MetsiConfiguration
 from lukefi.metsi.app.app_types import SimResults
 from lukefi.metsi.domain.utils.collectives import CollectFn, GetVarFn, compile, getvarfn, autocollective
 from lukefi.metsi.sim.core_types import OperationPayload
@@ -124,7 +124,7 @@ def j_out(data: SimResults,
         j_xda(f, data, xvariables)
 
 
-def parse_j_config(config: Mela2Configuration, decl: dict) -> dict:
+def parse_j_config(config: MetsiConfiguration, decl: dict) -> dict:
     return {
         'cda_filepath': Path(config.target_directory, decl.get("cda_filename", "data.cda")),
         'xda_filepath': Path(config.target_directory, decl.get("xda_filename", "data.xda")),

--- a/lukefi/metsi/app/file_io.py
+++ b/lukefi/metsi/app/file_io.py
@@ -7,7 +7,7 @@ from typing import Any, Callable, Iterator, Optional
 import yaml
 from lukefi.metsi.data.formats.ForestBuilder import VMI13Builder, VMI12Builder, ForestCentreBuilder
 from lukefi.metsi.data.formats.io_utils import stands_to_csv_content, csv_content_to_stands, stands_to_rsd_content
-from lukefi.metsi.app.app_io import Mela2Configuration
+from lukefi.metsi.app.app_io import MetsiConfiguration
 from lukefi.metsi.app.app_types import SimResults, ForestOpPayload
 from lukefi.metsi.domain.forestry_types import StandList
 from lukefi.metsi.sim.core_types import CollectedData
@@ -102,7 +102,7 @@ def external_reader(state_format: str, **builder_flags) -> StandReader:
         return lambda path: ForestCentreBuilder(builder_flags, xml_file_reader(path)).build()
 
 
-def read_stands_from_file(app_config: Mela2Configuration) -> StandList:
+def read_stands_from_file(app_config: MetsiConfiguration) -> StandList:
     """
     Read a list of ForestStands from given file with given configuration. Directly reads FDM format data. Utilizes
     FDM ForestBuilder utilities to transform VMI12, VMI13 or Forest Centre data into FDM ForestStand format.
@@ -204,7 +204,7 @@ def write_derived_data_to_file(result: CollectedData, filepath: Path, derived_da
     writer(filepath, result)
 
 
-def write_full_simulation_result_dirtree(result: SimResults, app_arguments: Mela2Configuration):
+def write_full_simulation_result_dirtree(result: SimResults, app_arguments: MetsiConfiguration):
     """
     Unwraps the given simulation result structure into computational units and further into produced schedules.
     Writes these as a matching directory structure, splitting OperationPayloads into unit_state and derived_data files.

--- a/lukefi/metsi/app/metsi.py
+++ b/lukefi/metsi/app/metsi.py
@@ -6,7 +6,7 @@ import warnings
 warnings.simplefilter(action='ignore', category=FutureWarning)
 
 import lukefi.metsi.app.preprocessor
-from lukefi.metsi.app.app_io import parse_cli_arguments, Mela2Configuration, generate_program_configuration, RunMode
+from lukefi.metsi.app.app_io import parse_cli_arguments, MetsiConfiguration, generate_program_configuration, RunMode
 from lukefi.metsi.app.app_types import SimResults
 from lukefi.metsi.domain.forestry_types import StandList
 from lukefi.metsi.app.export import export_files
@@ -17,7 +17,7 @@ from lukefi.metsi.app.simulator import simulate_alternatives
 from lukefi.metsi.app.console_logging import print_logline
 
 
-def preprocess(config: Mela2Configuration, control: dict, stands: StandList) -> StandList:
+def preprocess(config: MetsiConfiguration, control: dict, stands: StandList) -> StandList:
     print_logline("Preprocessing...")
     result = lukefi.metsi.app.preprocessor.preprocess_stands(stands, control)
     if config.preprocessing_output_container is not None:
@@ -27,7 +27,7 @@ def preprocess(config: Mela2Configuration, control: dict, stands: StandList) -> 
     return result
 
 
-def simulate(config: Mela2Configuration, control: dict, stands: StandList) -> SimResults:
+def simulate(config: MetsiConfiguration, control: dict, stands: StandList) -> SimResults:
     print_logline("Simulating alternatives...")
     result = simulate_alternatives(config, control, stands)
     if config.state_output_container is not None or config.derived_data_output_container is not None:
@@ -36,7 +36,7 @@ def simulate(config: Mela2Configuration, control: dict, stands: StandList) -> Si
     return result
 
 
-def post_process(config: Mela2Configuration, control: dict, data: SimResults) -> SimResults:
+def post_process(config: MetsiConfiguration, control: dict, data: SimResults) -> SimResults:
     print_logline("Post-processing alternatives...")
     result = post_process_alternatives(config, control['post_processing'], data)
     if config.state_output_container is not None or config.derived_data_output_container is not None:
@@ -45,7 +45,7 @@ def post_process(config: Mela2Configuration, control: dict, data: SimResults) ->
     return result
 
 
-def export(config: Mela2Configuration, control: dict, data: SimResults) -> None:
+def export(config: MetsiConfiguration, control: dict, data: SimResults) -> None:
     print_logline("Exporting data...")
     export_files(config, control['export'], data)
 
@@ -60,7 +60,7 @@ mode_runners = {
 
 def main() -> int:
     cli_arguments = parse_cli_arguments(sys.argv[1:])
-    control_file = Mela2Configuration.control_file if cli_arguments.control_file is None else cli_arguments.control_file
+    control_file = MetsiConfiguration.control_file if cli_arguments.control_file is None else cli_arguments.control_file
     try:
         control_structure = simulation_declaration_from_yaml_file(control_file)
     except IOError:

--- a/lukefi/metsi/app/post_processing.py
+++ b/lukefi/metsi/app/post_processing.py
@@ -1,4 +1,4 @@
-from lukefi.metsi.app.app_io import Mela2Configuration
+from lukefi.metsi.app.app_io import MetsiConfiguration
 from lukefi.metsi.app.app_types import SimResults
 from lukefi.metsi.domain.post_ops import operation_lookup
 from lukefi.metsi.sim.core_types import OperationPayload
@@ -6,7 +6,7 @@ from lukefi.metsi.sim.generators import simple_processable_chain
 from lukefi.metsi.sim.runners import evaluate_sequence
 
 
-def post_process_alternatives(config: Mela2Configuration, control: dict, input_data: SimResults):
+def post_process_alternatives(config: MetsiConfiguration, control: dict, input_data: SimResults):
     chain = simple_processable_chain(
         control.get('post_processing', []),
         control.get('operation_params', {}),

--- a/lukefi/metsi/app/simulator.py
+++ b/lukefi/metsi/app/simulator.py
@@ -3,7 +3,7 @@ import queue
 import multiprocessing
 import lukefi.metsi.domain.sim_ops
 import lukefi.metsi.sim.generators
-from lukefi.metsi.app.app_io import Mela2Configuration
+from lukefi.metsi.app.app_io import MetsiConfiguration
 from lukefi.metsi.app.app_types import ForestOpPayload
 from lukefi.metsi.app.console_logging import print_logline
 from lukefi.metsi.domain.forestry_types import StandList
@@ -83,7 +83,7 @@ def resolve_strategy_runner(source: str) -> StrategyRunner[ForestOpPayload]:
         raise Exception("Unable to resolve alternatives tree formation strategy '{}'".format(source))
 
 
-def simulate_alternatives(config: Mela2Configuration, control, stands: StandList):
+def simulate_alternatives(config: MetsiConfiguration, control, stands: StandList):
     simconfig = SimConfiguration(
         operation_lookup=lukefi.metsi.domain.sim_ops.operation_lookup,
         generator_lookup=lukefi.metsi.sim.generators.GENERATOR_LOOKUP,

--- a/lukefi/metsi/sim/core_types.py
+++ b/lukefi/metsi/sim/core_types.py
@@ -76,6 +76,31 @@ class Step:
                     result.append([self.operation] + chain)
             return result
 
+    def evaluate(self, payload) -> list:
+        """
+        Recursive pre-order walkthrough of this Step tree to evaluate its operations with the given payload,
+        copying it for branching.
+
+        :param payload: the simulation data payload (we don't care what it is here)
+        :return: list of result payloads from this Step or as concatenated from its branches
+        """
+        current = self.operation(payload)
+        if len(self.branches) == 0:
+            return [current]
+        elif len(self.branches) == 1:
+            return self.branches[0].evaluate(current)
+        elif len(self.branches) > 1:
+            results = []
+            for branch in self.branches:
+                try:
+                    results.extend(branch.evaluate(deepcopy(current)))
+                except UserWarning:
+                    ...
+            if len(results) == 0:
+                raise UserWarning(f"Branch aborted with all children failing")
+            else:
+                return results
+
     def add_branch(self, step: 'Step'):
         step.previous = self
         self.branches.append(step)

--- a/lukefi/metsi/sim/core_types.py
+++ b/lukefi/metsi/sim/core_types.py
@@ -8,7 +8,7 @@ def identity(x):
     return x
 
 
-class SimulationEvent(SimpleNamespace):
+class DeclaredEvents(SimpleNamespace):
     time_points: list[int] = []
     generators: list[dict] = {}
 
@@ -17,7 +17,7 @@ class SimConfiguration(SimpleNamespace):
     operation_lookup: dict[str, Callable] = {}
     operation_params: dict[str, list[dict[str, Any]]] = {}
     operation_file_params: dict[str, dict[str, str]] = {}
-    events: list[SimulationEvent] = []
+    events: list[DeclaredEvents] = []
     run_constraints: dict[str, dict] = {}
     time_points = []
 
@@ -30,7 +30,7 @@ class SimConfiguration(SimpleNamespace):
         self.events = list()
         for event_set in events:
             source_time_points = event_set.get('time_points', [])
-            new_event = SimulationEvent(
+            new_event = DeclaredEvents(
                 time_points=source_time_points,
                 generators=event_set.get('generators', [])
             )
@@ -39,30 +39,30 @@ class SimConfiguration(SimpleNamespace):
         self.time_points = sorted(time_points)
 
 
-class Step:
+class EventTree:
     """
-    Step represents a computational operation in a tree of alternative computation paths.
+    Event represents a computational operation in a tree of following event paths.
     """
     operation: Callable = identity  # default to the identity function, essentially no-op
-    branches: list['Step'] = []
-    previous: 'Step' or None = None
+    branches: list['EventTree'] = []
+    previous: 'EventTree' or None = None
 
     def __init__(self, operation: Callable[[Optional[Any]], Optional[Any]] or None = None,
-                 previous: 'Step' or None = None):
+                 previous: 'EventTree' or None = None):
         self.operation = operation if operation is not None else identity
         self.previous = previous
         self.branches = []
 
-    def find_root(self: 'Step'):
+    def find_root(self: 'EventTree'):
         return self if self.previous is None else self.previous.find_root()
 
-    def attach(self, previous: 'Step'):
+    def attach(self, previous: 'EventTree'):
         self.previous = previous
         previous.add_branch(self)
 
     def operation_chains(self):
         """
-        Recursively produce a list of lists of possible operation chains represented by this tree in post-order
+        Recursively produce a list of lists of possible operation chains represented by this event tree in post-order
         traversal.
         """
         if len(self.branches) == 0:
@@ -78,11 +78,11 @@ class Step:
 
     def evaluate(self, payload) -> list:
         """
-        Recursive pre-order walkthrough of this Step tree to evaluate its operations with the given payload,
+        Recursive pre-order walkthrough of this event tree to evaluate its operations with the given payload,
         copying it for branching.
 
         :param payload: the simulation data payload (we don't care what it is here)
-        :return: list of result payloads from this Step or as concatenated from its branches
+        :return: list of result payloads from this EventTree or as concatenated from its branches
         """
         current = self.operation(payload)
         if len(self.branches) == 0:
@@ -101,12 +101,12 @@ class Step:
             else:
                 return results
 
-    def add_branch(self, step: 'Step'):
-        step.previous = self
-        self.branches.append(step)
+    def add_branch(self, et: 'EventTree'):
+        et.previous = self
+        self.branches.append(et)
 
     def add_branch_from_operation(self, operation: Callable):
-        self.add_branch(Step(operation, self))
+        self.add_branch(EventTree(operation, self))
 
 
 class CollectedData:
@@ -207,5 +207,5 @@ class OperationPayload(SimpleNamespace, Generic[CUType]):
 OpTuple = tuple[CUType, CollectedData]
 SourceData = list[CUType]
 Evaluator = Callable[[OperationPayload[CUType]], list[OperationPayload[CUType]]]
-StrategyRunner = Callable[[OperationPayload[CUType], dict, dict, Evaluator[CUType]], list[OperationPayload[CUType]]]
-GeneratorFn = Callable[[Optional[list[Step]]], list[Step]]
+Runner = Callable[[OperationPayload[CUType], dict, dict, Evaluator[CUType]], list[OperationPayload[CUType]]]
+GeneratorFn = Callable[[Optional[list[EventTree]]], list[EventTree]]

--- a/lukefi/metsi/sim/core_types.py
+++ b/lukefi/metsi/sim/core_types.py
@@ -206,5 +206,6 @@ class OperationPayload(SimpleNamespace, Generic[CUType]):
 
 OpTuple = tuple[CUType, CollectedData]
 SourceData = list[CUType]
-StrategyRunner = Callable[[OperationPayload[CUType], dict, dict], list[OperationPayload[CUType]]]
+Evaluator = Callable[[OperationPayload[CUType]], list[OperationPayload[CUType]]]
+StrategyRunner = Callable[[OperationPayload[CUType], dict, dict, Evaluator[CUType]], list[OperationPayload[CUType]]]
 GeneratorFn = Callable[[Optional[list[Step]]], list[Step]]

--- a/lukefi/metsi/sim/runners.py
+++ b/lukefi/metsi/sim/runners.py
@@ -44,6 +44,10 @@ def chain_evaluator(payload: OperationPayload, root_step: Step) -> list[Operatio
     return run_chains_iteratively(payload, chains)
 
 
+def depth_first_evaluator(payload: OperationPayload, root_step: Step) -> list[OperationPayload]:
+    return root_step.evaluate(payload)
+
+
 def run_full_tree_strategy(payload: OperationPayload[CUType], config: SimConfiguration, evaluator=chain_evaluator) -> list[OperationPayload[CUType]]:
     """Process the given operation payload using a simulation state tree created from the declaration. Full simulation
     tree and operation chains are pre-generated for the run. This tree strategy creates the full theoretical branching

--- a/lukefi/metsi/sim/runners.py
+++ b/lukefi/metsi/sim/runners.py
@@ -1,6 +1,6 @@
 from typing import Optional, Callable
 from copy import deepcopy
-from lukefi.metsi.sim.core_types import OperationPayload, CUType, SimConfiguration
+from lukefi.metsi.sim.core_types import OperationPayload, CUType, SimConfiguration, Step
 from lukefi.metsi.sim.generators import full_tree_generators, compose_nested, partial_tree_generators_by_time_point
 
 
@@ -39,7 +39,12 @@ def run_chains_iteratively(payload, chains: list[list[Callable]]) -> list:
     return results
 
 
-def run_full_tree_strategy(payload: OperationPayload[CUType], config: SimConfiguration) -> list[OperationPayload[CUType]]:
+def chain_evaluator(payload: OperationPayload, root_step: Step) -> list[OperationPayload]:
+    chains = root_step.operation_chains()
+    return run_chains_iteratively(payload, chains)
+
+
+def run_full_tree_strategy(payload: OperationPayload[CUType], config: SimConfiguration, evaluator=chain_evaluator) -> list[OperationPayload[CUType]]:
     """Process the given operation payload using a simulation state tree created from the declaration. Full simulation
     tree and operation chains are pre-generated for the run. This tree strategy creates the full theoretical branching
     tree for the simulation, carrying a significant memory and runtime overhead for large trees.
@@ -50,33 +55,34 @@ def run_full_tree_strategy(payload: OperationPayload[CUType], config: SimConfigu
     """
 
     nestable_generator = full_tree_generators(config)
-    tree = compose_nested(nestable_generator)
-    chains = tree.operation_chains()
-    result = run_chains_iteratively(payload, chains)
+    root_step = compose_nested(nestable_generator)
+    result = evaluator(payload, root_step)
     return result
 
 
-def run_partial_tree_strategy(payload: OperationPayload[CUType], config: SimConfiguration) -> list[OperationPayload[CUType]]:
+def run_partial_tree_strategy(payload: OperationPayload[CUType], config: SimConfiguration, evaluator=chain_evaluator) -> list[OperationPayload[CUType]]:
     """Process the given operation payload using a simulation state tree created from the declaration. The simulation
     tree and operation chains are generated and executed in order per simulation time point. This reduces the amount of
     redundant, always-failing operation chains and redundant branches of the simulation tree.
 
     :param payload: a simulation state payload
     :param config: a prepared SimConfiguration object
+    :param evaluator: a function for performing computation from given Step and for given OperationPayload
     :return: a list of resulting simulation state payloads
     """
     generators_by_time_point = partial_tree_generators_by_time_point(config)
-    chains_by_time_point = {}
+    root_steps = {}
     results = [payload]
 
     #build chains_by_time_point, which is a dict of chains
     for time_point, nestable_generator in generators_by_time_point.items():
-        chains_by_time_point[time_point] = compose_nested(nestable_generator).operation_chains()
+        root_steps[time_point] = compose_nested(nestable_generator)
 
     for time_point in config.time_points:
+        root_step = root_steps[time_point]
         time_point_results: list[OperationPayload] = []
         for payload in results:
-            payload_results = run_chains_iteratively(payload, chains_by_time_point[time_point])
+            payload_results = evaluator(payload, root_step)
             time_point_results.extend(payload_results)
         results = time_point_results
     return results

--- a/tests/app/app_io_test.py
+++ b/tests/app/app_io_test.py
@@ -19,13 +19,14 @@ class TestAppIO(unittest.TestCase):
         self.assertEqual('fdm', result.state_format)
 
     def test_sim_cli_arguments(self):
-        args = ['input.pickle', 'output2', 'control.yaml', '-s', 'partial', '--state-format', 'fdm', '--reference-trees', '--strata-origin', '2']
+        args = ['input.pickle', 'output2', 'control.yaml', '-f', 'partial', '-e', 'depth', '--state-format', 'fdm', '--reference-trees', '--strata-origin', '2']
         result = aio.parse_cli_arguments(args)
-        self.assertEqual(13, len(result.__dict__.keys()))
+        self.assertEqual(15, len(result.__dict__.keys()))
         self.assertEqual('input.pickle', result.input_path)
         self.assertEqual('control.yaml', result.control_file)
         self.assertEqual('output2', result.target_directory)
-        self.assertEqual('partial', result.strategy)
+        self.assertEqual('partial', result.formation_strategy)
+        self.assertEqual('depth', result.evaluation_strategy)
         self.assertEqual('fdm', result.state_format)
         self.assertEqual(None, result.state_input_container)
         self.assertEqual(None, result.state_output_container)
@@ -74,7 +75,7 @@ class TestAppIO(unittest.TestCase):
         self.assertEqual('cli_input', result.input_path)
         self.assertEqual('cli_control.yaml', result.control_file)
         self.assertEqual('cli_output', result.target_directory)
-        self.assertEqual('full', result.strategy)
+        self.assertEqual('full', result.formation_strategy)
         self.assertEqual('vmi12', result.state_format)
         self.assertEqual('json', result.state_output_container)  # CLI overrides control source
         self.assertEqual('json', result.preprocessing_output_container)  # control source overrides Mela2Configuration

--- a/tests/app/app_io_test.py
+++ b/tests/app/app_io_test.py
@@ -61,10 +61,10 @@ class TestAppIO(unittest.TestCase):
         ]
 
         for case in successes:
-            result = lukefi.metsi.app.app_io.Mela2Configuration(run_modes=case[0]).run_modes
+            result = lukefi.metsi.app.app_io.MetsiConfiguration(run_modes=case[0]).run_modes
             self.assertEqual(case[1], result)
         for case in failures:
-            self.assertRaises(Exception, lukefi.metsi.app.app_io.Mela2Configuration, **{'run_modes': case})
+            self.assertRaises(Exception, lukefi.metsi.app.app_io.MetsiConfiguration, **{'run_modes': case})
 
     def test_mela2_configuration(self):
         args = ['cli_input', 'cli_output', 'cli_control.yaml', '-s', 'full', '--state-format', 'vmi12', '--state-output-container', 'json']

--- a/tests/app/file_io_test.py
+++ b/tests/app/file_io_test.py
@@ -7,7 +7,7 @@ import lukefi.metsi.app.file_io
 from dataclasses import dataclass
 from lukefi.metsi.data.model import ForestStand, ReferenceTree, TreeStratum
 
-from lukefi.metsi.app.app_io import Mela2Configuration
+from lukefi.metsi.app.app_io import MetsiConfiguration
 
 
 @dataclass
@@ -107,7 +107,7 @@ class TestFileReading(unittest.TestCase):
         shutil.rmtree('outdir')
 
     def test_read_stands_from_pickle_file(self):
-        config = Mela2Configuration(
+        config = MetsiConfiguration(
             input_path="tests/resources/file_io_test/forest_centre.pickle",
             state_format="fdm",
             state_input_container="pickle"
@@ -118,7 +118,7 @@ class TestFileReading(unittest.TestCase):
         self.assertEqual(type(unpickled_stands[0].tree_strata[0]), TreeStratum)
 
     def test_read_stands_from_json_file(self):
-        config = Mela2Configuration(
+        config = MetsiConfiguration(
             input_path="tests/resources/file_io_test/forest_centre.json",
             state_format="fdm",
             state_input_container="json"
@@ -129,7 +129,7 @@ class TestFileReading(unittest.TestCase):
         self.assertEqual(type(stands_from_json[0].tree_strata[0]), TreeStratum)
 
     def test_read_stands_from_csv_file(self):
-        config = Mela2Configuration(
+        config = MetsiConfiguration(
             input_path="tests/resources/file_io_test/forest_centre.csv",
             state_format="fdm",
             state_input_container="csv"
@@ -140,7 +140,7 @@ class TestFileReading(unittest.TestCase):
         self.assertEqual(type(stands_from_csv[0].tree_strata[0]), TreeStratum)
 
     def test_read_stands_from_vmi12_file(self):
-        config = Mela2Configuration(
+        config = MetsiConfiguration(
             input_path="tests/resources/file_io_test/vmi12.dat",
             state_format="vmi12",
             state_input_container=""
@@ -149,7 +149,7 @@ class TestFileReading(unittest.TestCase):
         self.assertEqual(len(stands), 4)
 
     def test_read_stands_from_vmi13_file(self):
-        config = Mela2Configuration(
+        config = MetsiConfiguration(
             input_path="tests/resources/file_io_test/vmi13.dat",
             state_format="vmi13",
             state_input_container=""
@@ -158,7 +158,7 @@ class TestFileReading(unittest.TestCase):
         self.assertEqual(len(stands), 3)
 
     def test_read_stands_from_xml_file(self):
-        config = Mela2Configuration(
+        config = MetsiConfiguration(
             input_path="tests/resources/file_io_test/forest_centre.xml",
             state_format="forest_centre",
             state_input_container=""
@@ -181,7 +181,7 @@ class TestFileReading(unittest.TestCase):
         self.assertEqual(2, len(result["3"][0].collected_data.get_list_result("calculate_biomass")))
 
     def test_read_stands_from_nonexisting_file(self):
-        config = Mela2Configuration(
+        config = MetsiConfiguration(
             input_path="nonexisting_file.pickle",
             state_format="fdm",
             state_input_container="pickle"

--- a/tests/domain/cross_cutting_test.py
+++ b/tests/domain/cross_cutting_test.py
@@ -1,7 +1,7 @@
 import unittest
 from lukefi.metsi.domain.data_collection.cross_cutting import cross_cut_standing_trees, cross_cut_felled_trees, cross_cut_tree, cross_cuttable_trees_from_stand
 from lukefi.metsi.domain.collected_types import CrossCutResult, CrossCuttableTree
-from lukefi.metsi.sim.core_types import CollectedData, OperationPayload, Step
+from lukefi.metsi.sim.core_types import CollectedData, OperationPayload, EventTree
 from lukefi.metsi.data.model import ForestStand, ReferenceTree
 from lukefi.metsi.data.enums.internal import TreeSpecies
 from lukefi.metsi.sim.generators import alternatives
@@ -333,7 +333,7 @@ class CrossCuttableTreesTest(unittest.TestCase):
         generator = lambda x: alternatives(x, *[cross_cut_processor, do_nothing_processor])
 
         generators = [generator]
-        root = Step()
+        root = EventTree()
         previous = [root]
         for generator in generators:
             current = generator(previous)

--- a/tests/sim/computation_model_test.py
+++ b/tests/sim/computation_model_test.py
@@ -35,6 +35,10 @@ class ComputationModelTest(unittest.TestCase):
             result = evaluate_sequence(0, *chain)
             self.assertEqual(3, result)
 
+    def test_evaluator(self):
+        results = self.root.evaluate(0)
+        self.assertListEqual([3, 3, 3, 3], results)
+
     def test_sim_configuration(self):
         fn1 = lambda x: x
         fn2 = lambda y: y

--- a/tests/sim/computation_model_test.py
+++ b/tests/sim/computation_model_test.py
@@ -2,28 +2,28 @@ import unittest
 
 from lukefi.metsi.sim.generators import sequence, alternatives
 from lukefi.metsi.sim.runners import evaluate_sequence
-from lukefi.metsi.sim.core_types import Step, SimConfiguration
+from lukefi.metsi.sim.core_types import EventTree, SimConfiguration
 from tests.test_utils import inc
 
 
 class ComputationModelTest(unittest.TestCase):
-    root = Step(inc)
+    root = EventTree(inc)
     root.branches = [
-        Step(inc),
-        Step(inc)
+        EventTree(inc),
+        EventTree(inc)
     ]
 
     root.branches[0].branches = [
-        Step(inc),
-        Step(inc)
+        EventTree(inc),
+        EventTree(inc)
     ]
 
     root.branches[1].branches = [
-        Step(inc),
-        Step(inc)
+        EventTree(inc),
+        EventTree(inc)
     ]
 
-    def test_step_generating(self):
+    def test_event_generating(self):
         chains = self.root.operation_chains()
         self.assertEqual(4, len(chains))
         self.assertEqual(3, len(chains[0]))

--- a/tests/sim/generators_test.py
+++ b/tests/sim/generators_test.py
@@ -1,15 +1,15 @@
 import unittest
 import lukefi.metsi.sim.generators
 import yaml
-from lukefi.metsi.sim.core_types import CollectedData, Step, OperationPayload, SimConfiguration
+from lukefi.metsi.sim.core_types import CollectedData, EventTree, OperationPayload, SimConfiguration
 from lukefi.metsi.sim.generators import sequence, compose_nested, alternatives
 from lukefi.metsi.sim.runners import evaluate_sequence as run_sequence, evaluate_sequence
 from tests.test_utils import inc, collecting_increment, parametrized_operation
 
 
 class TestGenerators(unittest.TestCase):
-    def test_step_sequence_generating(self):
-        root = Step()
+    def test_event_sequence_generating(self):
+        root = EventTree()
         result = sequence(
             [root],
             inc,
@@ -23,8 +23,8 @@ class TestGenerators(unittest.TestCase):
         self.assertEqual(4, len(chain))
 
     def test_branch_generating(self):
-        parent1 = Step()
-        parent2 = Step()
+        parent1 = EventTree()
+        parent2 = EventTree()
         result = alternatives(
             [parent1, parent2],
             *[inc, inc, inc]

--- a/tests/sim/performance_test.py
+++ b/tests/sim/performance_test.py
@@ -4,8 +4,7 @@ import unittest
 from lukefi.metsi.data.model import ForestStand, ReferenceTree
 from lukefi.metsi.sim.core_types import OperationPayload, SimConfiguration, CollectedData
 from lukefi.metsi.sim.generators import GENERATOR_LOOKUP
-from lukefi.metsi.sim.runners import run_full_tree_strategy, run_partial_tree_strategy
-
+from lukefi.metsi.sim.runners import run_full_tree_strategy, run_partial_tree_strategy, chain_evaluator
 
 optime = 0
 counter = 0
@@ -42,6 +41,7 @@ def create_sim_configs(workload_time):
             {'time_points': list(range(3)), 'generators': [{'alternatives': ['nodecount', 'nodecount', 'nodecount', 'nodecount']}]}
         ]}),
         SimConfiguration(operation_lookup={'nodecount': lambda x: nodecount(x, workload_time)}, generator_lookup=GENERATOR_LOOKUP, **{'simulation_events': [
+            {'time_points': [0], 'generators': [{'sequence': ['nodecount', 'nodecount', 'nodecount']}]},
             {'time_points': list(range(3)), 'generators': [{'alternatives': ['nodecount', 'nodecount', 'nodecount', 'nodecount', 'nodecount']}]}
         ]})
     ]
@@ -52,7 +52,12 @@ strategies = [
     run_partial_tree_strategy
 ]
 
-@unittest.skip
+
+evaluators = [
+    chain_evaluator
+]
+
+
 class PerformanceTest(unittest.TestCase):
     def test_constant_work_performance(self):
         """This is a manual test case created for observing the choice of run strategies related to the shape of the
@@ -78,17 +83,20 @@ class PerformanceTest(unittest.TestCase):
         counter = 0
 
         for si_n, sim in enumerate(sims):
+            print(f"sim {si_n}")
             for strategy in strategies:
-                payload = OperationPayload(computational_unit=fixture, collected_data=CollectedData(initial_time_point=sim.time_points[0]), operation_history=[])
-                start = time.time_ns()
-                result = strategy(payload, sim)
-                end = time.time_ns()
-                diff = round((end - start) / 1000000000, 3)
-                optime = round(optime, 3)
-                enginetime = round(diff - optime, 3)
-                print(f"strategy {strategy}, sim {si_n}")
-                print(f"   variants {len(result)}, operation calls {counter} ")
-                print(f"   total time {diff} s, operation time {optime} s, engine time {enginetime} s ({round(enginetime / diff * 100, 1)} % of total)")
-                optime = 0
-                counter = 0
+                print(f"  strategy {strategy.__name__}")
+                for evaluator in evaluators:
+                    print(f"    evaluator {evaluator.__name__}")
+                    payload = OperationPayload(computational_unit=fixture, collected_data=CollectedData(initial_time_point=sim.time_points[0]), operation_history=[])
+                    start = time.time_ns()
+                    result = strategy(payload, sim, evaluator)
+                    end = time.time_ns()
+                    diff = round((end - start) / 1000000000, 3)
+                    optime = round(optime, 3)
+                    enginetime = round(diff - optime, 3)
+                    print(f"      variants {len(result)}, operation calls {counter} ")
+                    print(f"      total time {diff} s, operation time {optime} s, engine time {enginetime} s ({round(enginetime / diff * 100, 1)} % of total)")
+                    optime = 0
+                    counter = 0
             print("\n")

--- a/tests/sim/performance_test.py
+++ b/tests/sim/performance_test.py
@@ -4,7 +4,7 @@ import unittest
 from lukefi.metsi.data.model import ForestStand, ReferenceTree
 from lukefi.metsi.sim.core_types import OperationPayload, SimConfiguration, CollectedData
 from lukefi.metsi.sim.generators import GENERATOR_LOOKUP
-from lukefi.metsi.sim.runners import run_full_tree_strategy, run_partial_tree_strategy, chain_evaluator
+from lukefi.metsi.sim.runners import run_full_tree_strategy, run_partial_tree_strategy, chain_evaluator, depth_first_evaluator
 
 optime = 0
 counter = 0
@@ -54,10 +54,12 @@ strategies = [
 
 
 evaluators = [
-    chain_evaluator
+    chain_evaluator,
+    depth_first_evaluator
 ]
 
 
+@unittest.skip
 class PerformanceTest(unittest.TestCase):
     def test_constant_work_performance(self):
         """This is a manual test case created for observing the choice of run strategies related to the shape of the

--- a/tests/sim/runners_test.py
+++ b/tests/sim/runners_test.py
@@ -26,7 +26,7 @@ class RunnersTest(unittest.TestCase):
         )
         self.assertRaises(Exception, prepared_function)
 
-    def test_step_tree_strategies_by_comparison(self):
+    def test_event_tree_formation_strategies_by_comparison(self):
         declaration = load_yaml('runners_test/branching.yaml')
         config = SimConfiguration(operation_lookup={'inc': collecting_increment}, generator_lookup=GENERATOR_LOOKUP, **declaration)
         print(config)
@@ -41,7 +41,7 @@ class RunnersTest(unittest.TestCase):
         self.assertEqual(8, len(results_partial))
         self.assertEqual(results_partial, results_full)
 
-    def test_full_tree_evaluators_by_comparison(self):
+    def test_full_formation_evaluation_strategies_by_comparison(self):
         declaration = load_yaml('runners_test/branching.yaml')
         config = SimConfiguration(operation_lookup={'inc': collecting_increment}, generator_lookup=GENERATOR_LOOKUP, **declaration)
         print(config)
@@ -62,7 +62,7 @@ class RunnersTest(unittest.TestCase):
         self.assertEqual(8, len(results_depth))
         self.assertEqual(results_chains, results_depth)
 
-    def test_partial_tree_evaluators_by_comparison(self):
+    def test_partial_formation_evaluation_strategies_by_comparison(self):
         declaration = load_yaml('runners_test/branching.yaml')
         config = SimConfiguration(operation_lookup={'inc': collecting_increment}, generator_lookup=GENERATOR_LOOKUP, **declaration)
         print(config)

--- a/tests/sim/runners_test.py
+++ b/tests/sim/runners_test.py
@@ -1,11 +1,12 @@
 import unittest
 from lukefi.metsi.sim.generators import GENERATOR_LOOKUP
 from lukefi.metsi.sim.core_types import CollectedData, OperationPayload, SimConfiguration
-from lukefi.metsi.sim.runners import evaluate_sequence, run_full_tree_strategy, run_partial_tree_strategy
+from lukefi.metsi.sim.runners import evaluate_sequence, run_full_tree_strategy, run_partial_tree_strategy, \
+    chain_evaluator, depth_first_evaluator
 from tests.test_utils import raises, identity, none, collect_results, load_yaml, collecting_increment
 
 
-class TestOperations(unittest.TestCase):
+class RunnersTest(unittest.TestCase):
     def test_sequence_success(self):
         payload = OperationPayload(computational_unit=1)
         result = evaluate_sequence(
@@ -25,7 +26,7 @@ class TestOperations(unittest.TestCase):
         )
         self.assertRaises(Exception, prepared_function)
 
-    def test_strategies_by_comparison(self):
+    def test_step_tree_strategies_by_comparison(self):
         declaration = load_yaml('runners_test/branching.yaml')
         config = SimConfiguration(operation_lookup={'inc': collecting_increment}, generator_lookup=GENERATOR_LOOKUP, **declaration)
         print(config)
@@ -39,6 +40,48 @@ class TestOperations(unittest.TestCase):
         self.assertEqual(8, len(results_full))
         self.assertEqual(8, len(results_partial))
         self.assertEqual(results_partial, results_full)
+
+    def test_full_tree_evaluators_by_comparison(self):
+        declaration = load_yaml('runners_test/branching.yaml')
+        config = SimConfiguration(operation_lookup={'inc': collecting_increment}, generator_lookup=GENERATOR_LOOKUP, **declaration)
+        print(config)
+        chains_payload = OperationPayload(
+            computational_unit=1,
+            collected_data=CollectedData(),
+            operation_history=[]
+        )
+        results_chains = collect_results(run_full_tree_strategy(chains_payload, config, chain_evaluator))
+
+        depth_payload = OperationPayload(
+            computational_unit=1,
+            collected_data=CollectedData(),
+            operation_history=[]
+        )
+        results_depth = collect_results(run_full_tree_strategy(depth_payload, config, depth_first_evaluator))
+        self.assertEqual(8, len(results_chains))
+        self.assertEqual(8, len(results_depth))
+        self.assertEqual(results_chains, results_depth)
+
+    def test_partial_tree_evaluators_by_comparison(self):
+        declaration = load_yaml('runners_test/branching.yaml')
+        config = SimConfiguration(operation_lookup={'inc': collecting_increment}, generator_lookup=GENERATOR_LOOKUP, **declaration)
+        print(config)
+        chains_payload = OperationPayload(
+            computational_unit=1,
+            collected_data=CollectedData(),
+            operation_history=[]
+        )
+        results_chains = collect_results(run_partial_tree_strategy(chains_payload, config, chain_evaluator))
+
+        depth_payload = OperationPayload(
+            computational_unit=1,
+            collected_data=CollectedData(),
+            operation_history=[]
+        )
+        results_depth = collect_results(run_partial_tree_strategy(depth_payload, config, depth_first_evaluator))
+        self.assertEqual(8, len(results_chains))
+        self.assertEqual(8, len(results_depth))
+        self.assertEqual(results_chains, results_depth)
 
     def test_no_parameters_propagation(self):
         declaration = load_yaml('runners_test/no_parameters.yaml')


### PR DESCRIPTION
Decided that evaluation is better name than execution for this.

Separated the concepts of step tree formation strategy (the old `strategy`) and step tree evaluation strategy.

Existing evaluation strategy is now called `chains`.

Added the depth-first evaluation strategy for the Step tree. This turned out to be a throw-in alternative for the evaluate operation chains approach. This strategy is called `depth`.

To take it into use, changed application configuration to have separate `formation_strategy` and `evaluation_strategy` parameters. The old `strategy` parameter has been left as a deprecated choice for backwards compatibility. Defaults have been set as `partial` and `depth` as the most performing solutions. `full` formation strategy has a danger of running into maximum recursion depth exceeded error with very deep trees.

Renamed the configuration class to MetsiConfiguration to reflect the new app name.

This solution was 25% faster for the reference case Pesola run.

closes #14 