### PR TITLE
feat: add debug feature for generate_reference_trees

### DIFF
--- a/control.yaml
+++ b/control.yaml
@@ -75,9 +75,7 @@ operation_params:
 preprocessing_params:
   generate_reference_trees:
     - n_trees: 10
-  filter:
-    - remove trees: sapling or stems_per_ha == 0
-      remove stands: site_type_category == 0 #not reference_trees
+      debug: false
 
 preprocessing_operations:
   - generate_reference_trees # reference trees from strata, replaces existing reference trees

--- a/lukefi/metsi/forestry/preprocessing/tree_generation_validation.py
+++ b/lukefi/metsi/forestry/preprocessing/tree_generation_validation.py
@@ -1,0 +1,67 @@
+from lukefi.metsi.data.model import TreeStratum, ReferenceTree, ForestStand
+from lukefi.metsi.forestry.forestry_utils import calculate_basal_area
+
+
+def weighted_mean(values: list[float], weights: list[float]) -> float:
+    if len(values) == 0 or len(weights) == 0:
+        return 0.0
+
+    divisor = sum(weights) if sum(weights) > 0 else len(weights)
+    return sum([value * weight for value, weight in zip(values, weights)]) / divisor
+
+
+def mean(values):
+    return 0.0 if len(values) == 0 else sum(values) / len(values)
+
+
+def round_each_numeric_value_in_list(values: list, decimals: int) -> list:
+    return [round(value, decimals) if isinstance(value, (int, float)) else value for value in values]
+
+
+def create_stratum_tree_comparison_set(stratum: TreeStratum, reference_trees: list[ReferenceTree]) -> dict[str, tuple[float, float]]:
+    return {
+        'basal_area': (stratum.basal_area, sum([calculate_basal_area(tree) for tree in reference_trees])),
+        'stems_per_ha': (stratum.stems_per_ha, sum([tree.stems_per_ha for tree in reference_trees if not tree.sapling])),
+        'sapling_stems_per_ha': (stratum.sapling_stems_per_ha, sum([tree.stems_per_ha for tree in reference_trees if tree.sapling])),
+        'mean_diameter': (stratum.mean_diameter, weighted_mean([tree.breast_height_diameter for tree in reference_trees], [calculate_basal_area(tree) for tree in reference_trees])),
+        'mean_height': (stratum.mean_height, weighted_mean([tree.height for tree in reference_trees], [calculate_basal_area(tree) for tree in reference_trees])),
+        'mean_age': (stratum.biological_age, mean([tree.biological_age for tree in reference_trees]))
+    }
+
+
+def debug_output_row_from_comparison_set(stratum: TreeStratum, comparison_set: dict[str, tuple[float, float]]) -> list:
+    rowdata = [
+        stratum.identifier,
+        comparison_set['basal_area'][0],
+        comparison_set['basal_area'][1],
+        comparison_set['stems_per_ha'][0],
+        comparison_set['stems_per_ha'][1],
+        comparison_set['sapling_stems_per_ha'][0],
+        comparison_set['sapling_stems_per_ha'][1],
+        comparison_set['mean_diameter'][0],
+        comparison_set['mean_diameter'][1],
+        comparison_set['mean_height'][0],
+        comparison_set['mean_height'][1],
+        comparison_set['mean_age'][0],
+        comparison_set['mean_age'][1]
+    ]
+
+    return round_each_numeric_value_in_list(rowdata, 2)
+
+
+def debug_output_header_row() -> list:
+    return [
+        'stratum_id',
+        'strat_G',
+        'trees_G',
+        'strat_stems',
+        'trees_stems',
+        'strat_sap_stems',
+        'trees_sap_stems',
+        'strat_d',
+        'trees_d',
+        'strat_h',
+        'trees_h',
+        'strat_a',
+        'trees_a'
+    ]

--- a/tests/domain/preprocessing_test.py
+++ b/tests/domain/preprocessing_test.py
@@ -31,8 +31,8 @@ class PreprocessingTest(unittest.TestCase):
         """ In this suite there are two stratum fixture cases.
         A stratum that has all necessary attributes inflated and one that needs mean diameter to be supplemented
         """
-        normal_case = TreeStratum(mean_diameter=17.0, mean_height=15.0, basal_area=250.0, stems_per_ha=None)
-        supplement_diameter_case = TreeStratum(mean_diameter=None, mean_height=25.0, basal_area=250.0, stems_per_ha=300.0)
+        normal_case = TreeStratum(mean_diameter=17.0, mean_height=15.0, basal_area=250.0, stems_per_ha=None, biological_age=10.0)
+        supplement_diameter_case = TreeStratum(mean_diameter=None, mean_height=25.0, basal_area=250.0, stems_per_ha=300.0, biological_age=15.0)
         fixtures = [normal_case, supplement_diameter_case]
         stand = ForestStand()
         stand.identifier = 'xxx'


### PR DESCRIPTION
This allows outputting a csv file for comparing stratum values to generated tree statistics. For this purpose, and for future automatic validation, a validation module was introduced. Specs for a more generic validation feature are still unknown, so future redesign is crucial.

For posterity, this commit carries significant technical debt risk. Debug feature should become more general along with its file output facilities. This kind of IO does not belong in an operation function like generate_reference_trees. Apologies in advance...