### PR TITLE
Area weights

### DIFF
--- a/lukefi/metsi/data/conversion/internal2mela.py
+++ b/lukefi/metsi/data/conversion/internal2mela.py
@@ -231,7 +231,7 @@ def mela_stand(stand):
     """Convert a ForestStand so that enumerated category variables are converted to Mela value space"""
     result = copy(stand)
     result.geo_location = copy(stand.geo_location)
-    result.stems_per_ha_scaling_factors = copy(stand.stems_per_ha_scaling_factors)
+    result.area_weight_factors = copy(stand.area_weight_factors)
     result = apply_mappers(result, *default_mela_stand_mappers)
     result.reference_trees = list(map(mela_tree, result.reference_trees))
     for tree in result.reference_trees:

--- a/lukefi/metsi/data/formats/ForestBuilder.py
+++ b/lukefi/metsi/data/formats/ForestBuilder.py
@@ -162,11 +162,11 @@ class VMI12Builder(VMIBuilder):
         area_ha = vmi_util.determine_vmi12_area_ha(
             int(data_row[indices.lohkomuoto]),
             int(data_row[indices.county]))
-        result.stems_per_ha_scaling_factors = vmi_util.determine_area_factors(
+        result.area_weight_factors = vmi_util.determine_area_factors(
             data_row[indices.osuus5m],
             data_row[indices.osuus9m]
         )
-        area_weight = area_ha * result.stems_per_ha_scaling_factors[1]
+        area_weight = area_ha * result.area_weight_factors[1]
         result.set_area(area_ha, area_weight)
         lat = vmi_util.parse_float(data_row[indices.lat])
         lon = vmi_util.parse_float(data_row[indices.lon])
@@ -254,11 +254,11 @@ class VMI13Builder(VMIBuilder):
         result = super().convert_stand_entry(indices, data_row, stand_id)
         result.year = vmi_util.parse_vmi13_date(data_row[indices.date]).year
         area_ha = vmi_util.determine_vmi13_area_ha(int(data_row[indices.lohkomuoto]))
-        result.stems_per_ha_scaling_factors = vmi_util.determine_area_factors(
+        result.area_weight_factors = vmi_util.determine_area_factors(
             data_row[indices.osuus4m],
             data_row[indices.osuus9m]
         )
-        area_weight = area_ha * result.stems_per_ha_scaling_factors[1]
+        area_weight = area_ha * result.area_weight_factors[1]
         result.set_area(area_ha, area_weight)
         lat = vmi_util.parse_float(data_row[indices.lat])
         lon = vmi_util.parse_float(data_row[indices.lon])
@@ -433,7 +433,7 @@ class ForestCentreBuilder(XMLBuilder):
         stand.forestry_centre_id = -1 # RSD record 29
         stand.forest_management_category = smk_util.parse_forest_management_category(stand_basic_data.CuttingRestriction) or 1  # 30
         stand.municipality_id = None or -1 # RSD record 32
-        stand.stems_per_ha_scaling_factors = (1.0, 1.0)
+        stand.area_weight_factors = (1.0, 1.0)
         # RSD record 33 and 34 unused
         return stand
 

--- a/lukefi/metsi/data/formats/ForestBuilder.py
+++ b/lukefi/metsi/data/formats/ForestBuilder.py
@@ -162,7 +162,12 @@ class VMI12Builder(VMIBuilder):
         area_ha = vmi_util.determine_vmi12_area_ha(
             int(data_row[indices.lohkomuoto]),
             int(data_row[indices.county]))
-        result.set_area(area_ha)
+        result.stems_per_ha_scaling_factors = vmi_util.determine_area_factors(
+            data_row[indices.osuus5m],
+            data_row[indices.osuus9m]
+        )
+        area_weight = area_ha * result.stems_per_ha_scaling_factors[1]
+        result.set_area(area_ha, area_weight)
         lat = vmi_util.parse_float(data_row[indices.lat])
         lon = vmi_util.parse_float(data_row[indices.lon])
         height = vmi_util.transform_vmi12_height_above_sea_level(data_row[indices.height_above_sea_level])
@@ -187,10 +192,6 @@ class VMI12Builder(VMIBuilder):
         result.young_stand_tending_year = maintenance_details[0]
         result.cutting_year = maintenance_details[1]
         result.method_of_last_cutting = maintenance_details[2]
-        result.stems_per_ha_scaling_factors = vmi_util.determine_area_factors(
-            data_row[indices.osuus5m],
-            data_row[indices.osuus9m]
-        )
         return result
 
     def convert_tree_entry(self, indices: VMI12TreeIndices, data_row: Sequence):
@@ -253,7 +254,12 @@ class VMI13Builder(VMIBuilder):
         result = super().convert_stand_entry(indices, data_row, stand_id)
         result.year = vmi_util.parse_vmi13_date(data_row[indices.date]).year
         area_ha = vmi_util.determine_vmi13_area_ha(int(data_row[indices.lohkomuoto]))
-        result.set_area(area_ha)
+        result.stems_per_ha_scaling_factors = vmi_util.determine_area_factors(
+            data_row[indices.osuus4m],
+            data_row[indices.osuus9m]
+        )
+        area_weight = area_ha * result.stems_per_ha_scaling_factors[1]
+        result.set_area(area_ha, area_weight)
         lat = vmi_util.parse_float(data_row[indices.lat])
         lon = vmi_util.parse_float(data_row[indices.lon])
         height = vmi_util.transform_vmi13_height_above_sea_level(data_row[indices.height_above_sea_level])
@@ -279,10 +285,6 @@ class VMI13Builder(VMIBuilder):
         result.young_stand_tending_year = maintenance_details[0]
         result.cutting_year = maintenance_details[1]
         result.method_of_last_cutting = maintenance_details[2]
-        result.stems_per_ha_scaling_factors = vmi_util.determine_area_factors(
-            data_row[indices.osuus4m],
-            data_row[indices.osuus9m]
-        )
         return result
 
     def convert_tree_entry(self, indices: VMI13TreeIndices, data_row: Sequence):

--- a/lukefi/metsi/data/formats/util.py
+++ b/lukefi/metsi/data/formats/util.py
@@ -37,7 +37,7 @@ def convert_str_to_type(_class: type, value: str, property_name: str):
         return property_type.__args__[0][value.split('.')[1]]
 
     if type(value) == tuple:
-        #stand.stems_per_ha_scaling_factors
+        #stand.area_weight_factors
         if property_type == tuple[float, float]:
             return tuple(parse_float(v) for v in value)
         #stand.geo_location

--- a/lukefi/metsi/data/model.py
+++ b/lukefi/metsi/data/model.py
@@ -447,7 +447,7 @@ class ForestStand():
     # RSD record 33 and 34 unused
 
     # stand specific factors for scaling estimated ReferenceTree count per hectare
-    stems_per_ha_scaling_factors: tuple[float, float] = (1.0, 1.0)
+    area_weight_factors: tuple[float, float] = (1.0, 1.0)
 
     fra_category: Optional[str] = None  # VMI fra category
     # VMI land use category detail
@@ -562,8 +562,8 @@ class ForestStand():
             self.fra_category,
             self.land_use_category_detail,
             self.auxiliary_stand,
-            self.stems_per_ha_scaling_factors[0],
-            self.stems_per_ha_scaling_factors[1],
+            self.area_weight_factors[0],
+            self.area_weight_factors[1],
             self.stand_id,
             self.basal_area
         ]
@@ -609,7 +609,7 @@ class ForestStand():
         self.fra_category = conv(row[31], "fra_category")
         self.land_use_category_detail = conv(row[32], "land_use_category_detail")
         self.auxiliary_stand = conv(row[33], "auxiliary_stand")
-        self.stems_per_ha_scaling_factors = conv((row[34], row[35]), "stems_per_ha_scaling_factors")
+        self.area_weight_factors = conv((row[34], row[35]), "area_weight_factors")
         self.stand_id = conv(row[36], "stand_id")
         self.basal_area = conv(row[37], "basal_area")
 

--- a/lukefi/metsi/forestry/preprocessing/pre_util.py
+++ b/lukefi/metsi/forestry/preprocessing/pre_util.py
@@ -9,16 +9,6 @@ def get_or_default(maybe: Optional[Any], default: Any = None) -> Any:
     return default if maybe is None else maybe
 
 
-# ---- domain utils ----
-
-def scale_stems_per_ha(trees: list[ReferenceTree], area_factors: tuple[float, float]) -> list[ReferenceTree]:
-    """Scale the given ReferenceTree instances with the given area factors based on diameter cutoff at 0.94 dm"""
-    for tree in trees:
-        factor = area_factors[0] if tree.breast_height_diameter <= 0.94 else area_factors[1]
-        tree.stems_per_ha = tree.stems_per_ha * factor
-    return trees
-
-
 # ---- state utils ----
 
 def stratum_needs_diameter(stratum: TreeStratum) -> bool:

--- a/lukefi/metsi/forestry/preprocessing/tree_generation.py
+++ b/lukefi/metsi/forestry/preprocessing/tree_generation.py
@@ -102,10 +102,8 @@ def reference_trees_from_tree_stratum(stratum: TreeStratum, **params) -> list[Re
     result = []
     if strategy == TreeStrategy.HEIGHT_DISTRIBUTION:
         result = trees_from_sapling_height_distribution(stratum, **params)
-        result = pre_util.scale_stems_per_ha(result, stratum.stand.stems_per_ha_scaling_factors)
     elif strategy == TreeStrategy.WEIBULL_DISTRIBUTION:
         result = trees_from_weibull(stratum, **params)
-        result = pre_util.scale_stems_per_ha(result, stratum.stand.stems_per_ha_scaling_factors)
     elif strategy == TreeStrategy.LM_TREES:
         result = tree_generation_lm(stratum, stratum.stand.degree_days, stratum.stand.basal_area, **params)
     elif strategy == TreeStrategy.SKIP:

--- a/tests/data/vmi_builder_test.py
+++ b/tests/data/vmi_builder_test.py
@@ -185,9 +185,9 @@ class TestForestBuilder(unittest.TestCase):
         # municipality is '417', kitukunta is '417'
         self.assertEqual(417, self.vmi12_stands[1].municipality_id)
         # osuus564 is '10', koealaosuudet is '10'
-        self.assertEqual((1.0, 1.0), self.vmi12_stands[0].stems_per_ha_scaling_factors)
+        self.assertEqual((1.0, 1.0), self.vmi12_stands[0].area_weight_factors)
         # osuus564 is '10', koealaosuudet is '10'
-        self.assertEqual((1.0, 1.0), self.vmi12_stands[1].stems_per_ha_scaling_factors)
+        self.assertEqual((1.0, 1.0), self.vmi12_stands[1].area_weight_factors)
         self.assertEqual(False, self.vmi12_stands[0].auxiliary_stand)
         self.assertEqual(False, self.vmi12_stands[1].auxiliary_stand)
         self.assertEqual(None, self.vmi12_stands[0].basal_area)
@@ -393,9 +393,9 @@ class TestForestBuilder(unittest.TestCase):
         # municipality is '11', kitukunta '402'
         self.assertEqual(11, self.vmi13_stands[1].municipality_id)
         # osuus4m is '10', osuus9m is '10'
-        self.assertEqual((1.0, 1.0), self.vmi13_stands[0].stems_per_ha_scaling_factors)
+        self.assertEqual((1.0, 1.0), self.vmi13_stands[0].area_weight_factors)
         # osuus4m is '10', osuus9m is '10'
-        self.assertEqual((1.0, 1.0), self.vmi13_stands[1].stems_per_ha_scaling_factors)
+        self.assertEqual((1.0, 1.0), self.vmi13_stands[1].area_weight_factors)
         self.assertEqual(False, self.vmi13_stands[0].auxiliary_stand)
         self.assertEqual(False, self.vmi13_stands[1].auxiliary_stand)
         self.assertEqual(26, self.vmi13_stands[0].basal_area)

--- a/tests/data/vmi_builder_test.py
+++ b/tests/data/vmi_builder_test.py
@@ -84,7 +84,7 @@ class TestForestBuilder(unittest.TestCase):
         self.assertEqual(230.8291, self.vmi12_stands[3].area)
         self.assertEqual(reference_area, self.vmi12_stands[0].area_weight)
         self.assertEqual(reference_area, self.vmi12_stands[1].area_weight)
-        self.assertEqual(230.8291, self.vmi12_stands[3].area_weight)
+        self.assertAlmostEqual(23.08291, self.vmi12_stands[3].area_weight, 5)
 
         # lat 6656996, lon 3102608, height
         self.assertEqual((6652133.0, 3246174.0, None, 'EPSG:2393'), self.vmi12_stands[0].geo_location)

--- a/tests/domain/preprocessing_test.py
+++ b/tests/domain/preprocessing_test.py
@@ -31,7 +31,7 @@ class PreprocessingTest(unittest.TestCase):
         normal_case = TreeStratum(identifier="1-stratum", mean_diameter=17.0, mean_height=15.0, basal_area=250.0, stems_per_ha=None, biological_age=10.0, sapling_stratum=False)
         stand = ForestStand()
         stand.identifier = 'xxx'
-        stand.stems_per_ha_scaling_factors = (1.0, 1.0)
+        stand.area_weight_factors = (1.0, 1.0)
         stand.tree_strata.append(normal_case)
         normal_case.stand = stand
         result = preprocessing.generate_reference_trees([stand], n_trees=10)

--- a/tests/forestry/preprocessing_tests/pre_util_test.py
+++ b/tests/forestry/preprocessing_tests/pre_util_test.py
@@ -33,16 +33,3 @@ class TestPreprocessingUtils(unittest.TestCase):
             stratum.mean_diameter = i[0][1]
             result = pre_util.supplement_mean_diameter(stratum)
             self.assertEqual(i[1], result.mean_diameter)
-
-    def test_stems_scaling(self):
-        factors = (2.0, 4.0)
-        reftree1 = ReferenceTree()
-        reftree1.stems_per_ha = 10
-        reftree1.breast_height_diameter = 0.5
-        reftree2 = ReferenceTree()
-        reftree2.stems_per_ha = 10
-        reftree2.breast_height_diameter = 1
-        scaled = pre_util.scale_stems_per_ha([reftree1, reftree2], factors)
-
-        self.assertEqual(20.0, scaled[0].stems_per_ha)
-        self.assertEqual(40.0, scaled[1].stems_per_ha)

--- a/tests/resources/file_io_test/forest_centre.json
+++ b/tests/resources/file_io_test/forest_centre.json
@@ -204,7 +204,7 @@
     "forest_management_category": 1,
     "method_of_last_cutting": null,
     "municipality_id": null,
-    "stems_per_ha_scaling_factors": {
+    "area_weight_factors": {
       "py/tuple": [
         1.0,
         1.0
@@ -279,7 +279,7 @@
     "forest_management_category": 1,
     "method_of_last_cutting": null,
     "municipality_id": null,
-    "stems_per_ha_scaling_factors": {
+    "area_weight_factors": {
       "py/tuple": [
         1.0,
         1.0


### PR DESCRIPTION
closes #36 and #37

ForestStand area_weight is now computed based on the 9m radius proportion.

Weibull generated trees no longer use the radius proportion weights to scale stem counts.