### PR TITLE
Common area weights

### DIFF
--- a/control.yaml
+++ b/control.yaml
@@ -82,6 +82,7 @@ preprocessing_params:
   #    remove stands: site_type_category == 0 #not reference_trees
 
 preprocessing_operations:
+  - scale_area_weight
   - generate_reference_trees # reference trees from strata, replaces existing reference trees
   #- supplement_missing_tree_heights
   #- supplement_missing_tree_ages

--- a/lukefi/metsi/data/formats/ForestBuilder.py
+++ b/lukefi/metsi/data/formats/ForestBuilder.py
@@ -168,8 +168,7 @@ class VMI12Builder(VMIBuilder):
             data_row[indices.osuus5m],
             data_row[indices.osuus9m]
         )
-        area_weight = area_ha * result.area_weight_factors[1]
-        result.set_area(area_ha, area_weight)
+        result.set_area(area_ha)
         lat = vmi_util.parse_float(data_row[indices.lat])
         lon = vmi_util.parse_float(data_row[indices.lon])
         height = vmi_util.transform_vmi12_height_above_sea_level(data_row[indices.height_above_sea_level])
@@ -260,8 +259,7 @@ class VMI13Builder(VMIBuilder):
             data_row[indices.osuus4m],
             data_row[indices.osuus9m]
         )
-        area_weight = area_ha * result.area_weight_factors[1]
-        result.set_area(area_ha, area_weight)
+        result.set_area(area_ha)
         lat = vmi_util.parse_float(data_row[indices.lat])
         lon = vmi_util.parse_float(data_row[indices.lon])
         height = vmi_util.transform_vmi13_height_above_sea_level(data_row[indices.height_above_sea_level])
@@ -412,8 +410,7 @@ class ForestCentreBuilder(XMLBuilder):
         stand = ForestStand()
         stand.management_unit_id = None # RSD record 1
         stand.year = smk_util.parse_year(stand_basic_data.StandBasicDataDate) # RSD record 2
-        stand.area = util.parse_float(stand_basic_data.Area) # RSD record 3
-        stand.area_weight = stand.area # RSD record 4
+        stand.set_area(util.parse_float(stand_basic_data.Area)) # RSD record 3 and 4
         (latitude, longitude, crs) = smk_util.parse_coordinates(estand)
         stand.geo_location = (latitude, longitude, None, crs) # RSD record 5,6,8
         stand.identifier = stand_basic_data.id # RSD record 7
@@ -493,7 +490,7 @@ class GeoPackageBuilder(ForestBuilder):
         stand = ForestStand()
         stand.management_unit_id = None # RSD record 1
         stand.year = smk_util.parse_year(entry.date) # RSD record 2
-        stand.area = entry.area - entry.areadecrease # RSD record 3
+        stand.set_area(entry.area - entry.areadecrease) # RSD record 3 and 4
         stand.area_weight = stand.area # RSD record 4
         # RSD records 5, 6 and 8
         (latitude, longitude) = entry.centroid.get('centroid')

--- a/lukefi/metsi/data/formats/ForestBuilder.py
+++ b/lukefi/metsi/data/formats/ForestBuilder.py
@@ -1,7 +1,6 @@
 from collections.abc import Sequence, Iterable
 import xml.etree.ElementTree as ET
 from pandas import DataFrame, Series
-from geopandas import GeoDataFrame
 
 from lukefi.metsi.data.enums.internal import OwnerCategory
 from lukefi.metsi.data.formats.util import parse_float
@@ -491,7 +490,6 @@ class GeoPackageBuilder(ForestBuilder):
         stand.management_unit_id = None # RSD record 1
         stand.year = smk_util.parse_year(entry.date) # RSD record 2
         stand.set_area(entry.area - entry.areadecrease) # RSD record 3 and 4
-        stand.area_weight = stand.area # RSD record 4
         # RSD records 5, 6 and 8
         (latitude, longitude) = entry.centroid.get('centroid')
         stand.geo_location = (latitude,

--- a/lukefi/metsi/data/formats/vmi_util.py
+++ b/lukefi/metsi/data/formats/vmi_util.py
@@ -11,11 +11,8 @@ from geopandas import GeoSeries
 
 def determine_area_factors(small_tree_sourcevalue: str, big_tree_sourcevalue: str) -> tuple[float, float]:
     """Compute forest stand specific scaling factors for area and reference tree stem count scaling."""
-    default_rsd_value = 1.0
-    small = get_or_default(parse_float(small_tree_sourcevalue), 0.0)
-    big = get_or_default(parse_float(big_tree_sourcevalue), 0.0)
-    small = default_rsd_value if small == 0.0 else small / 10.0
-    big = default_rsd_value if big == 0.0 else big / 10.0
+    small = get_or_default(parse_float(small_tree_sourcevalue), 0.0) / 10
+    big = get_or_default(parse_float(big_tree_sourcevalue), 0.0) / 10
     return small, big
 
 

--- a/lukefi/metsi/data/model.py
+++ b/lukefi/metsi/data/model.py
@@ -485,9 +485,12 @@ class ForestStand():
             stand_id if management_unit_id is None else management_unit_id
         )
 
-    def set_area(self, area_ha: float, area_weight: Optional[float] = None):
-        self.area = area_ha
-        self.area_weight = area_ha if area_weight is None else area_weight
+    def set_area(self, area_ha: float):
+        if self.is_auxiliary():
+            self.area = 0.0
+        else:
+            self.area = area_ha
+        self.area_weight = area_ha
 
     def set_geo_location(
         self, lat: float, lon: float, height: float, system: str = "EPSG:3067"

--- a/lukefi/metsi/domain/pre_ops.py
+++ b/lukefi/metsi/domain/pre_ops.py
@@ -71,6 +71,7 @@ def generate_reference_trees(stands: list[ForestStand], **operation_params) -> l
     debug_tree_rows = []
     stratum_association_diameter_threshold = operation_params.get('stratum_association_diameter_threshold', 2.5)
     for i, stand in enumerate(stands):
+        stand.area_weight = stand.area * stand.area_weight_factors[1]
         print(f"\rGenerating trees for stand {stand.identifier}    {i}/{len(stands)}", end="")
         stand_trees = sorted(stand.reference_trees, key=lambda tree: tree.identifier)
         for tree in stand_trees:

--- a/lukefi/metsi/domain/pre_ops.py
+++ b/lukefi/metsi/domain/pre_ops.py
@@ -61,8 +61,6 @@ def compute_location_metadata(stands: list[ForestStand], **operation_params) -> 
     return stands
 
 
-
-
 def generate_reference_trees(stands: list[ForestStand], **operation_params) -> list[ForestStand]:
     """ Operation function that generates (N * stratum) reference trees for each stand """
     debug = operation_params.get('debug', False)
@@ -71,7 +69,6 @@ def generate_reference_trees(stands: list[ForestStand], **operation_params) -> l
     debug_tree_rows = []
     stratum_association_diameter_threshold = operation_params.get('stratum_association_diameter_threshold', 2.5)
     for i, stand in enumerate(stands):
-        stand.area_weight = stand.area * stand.area_weight_factors[1]
         print(f"\rGenerating trees for stand {stand.identifier}    {i}/{len(stands)}", end="")
         stand_trees = sorted(stand.reference_trees, key=lambda tree: tree.identifier)
         for tree in stand_trees:
@@ -182,6 +179,17 @@ def generate_sapling_trees_from_sapling_strata(stands: list[ForestStand], **oper
     return stands
 
 
+def scale_area_weight(stands: list[ForestStand], **operation_params):
+    """ Scales area weight of a stand.
+    
+        Especially necessary for VMI tree generation cases.
+        Should be used as precesing operation before the generation of reference trees.
+    """
+    for stand in stands:
+        stand.area_weight = stand.area_weight * stand.area_weight_factors[1]
+    return stands
+
+
 operation_lookup = {
     'filter': preproc_filter,
     'compute_location_metadata': compute_location_metadata,
@@ -189,5 +197,6 @@ operation_lookup = {
     'supplement_missing_tree_heights': supplement_missing_tree_heights,
     'supplement_missing_tree_ages': supplement_missing_tree_ages,
     'supplement_missing_stratum_diameters': supplement_missing_stratum_diameters,
-    'generate_sapling_trees_from_sapling_strata': generate_sapling_trees_from_sapling_strata
+    'generate_sapling_trees_from_sapling_strata': generate_sapling_trees_from_sapling_strata,
+    'scale_area_weight': scale_area_weight
 }

--- a/tests/data/conversion_test.py
+++ b/tests/data/conversion_test.py
@@ -6,13 +6,12 @@ from tests.data import test_util
 class TestConversion(test_util.ConverterTestSuite):
     def test_determine_area_factors(self):
         assertions = [
-            (['0', '0'], (1.0, 1.0)),
-            (['0', '1'], (1.0, 0.1)),
-            (['1', '0'], (0.1, 1.0)),
-            (['2', '4'], (0.2, 0.4)),
-            (['2', None], (0.2, 1.0)),
-            ([None, '4'], (1.0, 0.4)),
-            ([None, None], (1.0, 1.0)),
+            (['0', '0'], (0.0, 0.0)),
+            (['0', '1'], (0.0, 0.1)),
+            (['1', '0'], (0.1, 0.0)),
+            (['2', None], (0.2, 0.0)),
+            ([None, '4'], (0.0, 0.4)),
+            ([None, None], (0.0, 0.0)),
         ]
 
         self.run_with_test_assertions(assertions, vmi_util.determine_area_factors)

--- a/tests/data/conversion_test.py
+++ b/tests/data/conversion_test.py
@@ -12,6 +12,7 @@ class TestConversion(test_util.ConverterTestSuite):
             (['2', None], (0.2, 0.0)),
             ([None, '4'], (0.0, 0.4)),
             ([None, None], (0.0, 0.0)),
+            (['2', '4'], (0.2, 0.4)),
         ]
 
         self.run_with_test_assertions(assertions, vmi_util.determine_area_factors)

--- a/tests/data/model_test.py
+++ b/tests/data/model_test.py
@@ -144,9 +144,9 @@ class TestForestDataModel(unittest.TestCase):
 
     def test_set_area_with_weight(self):
         fixture = ForestStand()
-        fixture.set_area(1.0, 2.0)
+        fixture.set_area(1.0)
         self.assertEqual(1.0, fixture.area)
-        self.assertEqual(2.0, fixture.area_weight)
+        self.assertEqual(1.0, fixture.area_weight)
 
     def test_set_geo_location(self):
         fixture = ForestStand()

--- a/tests/data/vmi_builder_test.py
+++ b/tests/data/vmi_builder_test.py
@@ -81,10 +81,10 @@ class TestForestBuilder(unittest.TestCase):
         self.assertEqual(reference_area, self.vmi12_stands[0].area)
         self.assertEqual(reference_area, self.vmi12_stands[1].area)
         #auxiliary stand area should be 0
-        self.assertEqual(230.8291, self.vmi12_stands[3].area)
+        self.assertEqual(0.0, self.vmi12_stands[3].area)
         self.assertEqual(reference_area, self.vmi12_stands[0].area_weight)
         self.assertEqual(reference_area, self.vmi12_stands[1].area_weight)
-        self.assertAlmostEqual(23.08291, self.vmi12_stands[3].area_weight, 5)
+        self.assertAlmostEqual(reference_area, self.vmi12_stands[3].area_weight)
 
         # lat 6656996, lon 3102608, height
         self.assertEqual((6652133.0, 3246174.0, None, 'EPSG:2393'), self.vmi12_stands[0].geo_location)
@@ -286,10 +286,10 @@ class TestForestBuilder(unittest.TestCase):
         self.assertEqual(reference_area, self.vmi13_stands[0].area)
         self.assertEqual(reference_area, self.vmi13_stands[1].area)
         #auxiliary stand area should be 0
-        self.assertEqual(436.0, self.vmi13_stands[2].area)
+        self.assertEqual(0.0, self.vmi13_stands[2].area)
         self.assertEqual(reference_area, self.vmi13_stands[0].area_weight)
         self.assertEqual(reference_area, self.vmi13_stands[1].area_weight)
-        self.assertEqual(436.0, self.vmi13_stands[2].area_weight)
+        self.assertEqual(reference_area, self.vmi13_stands[2].area_weight)
         # lat 7025056.83, lon 589991.91, height 179.70
         self.assertEqual((7013044.52, 543791.23, 179.7, 'EPSG:3067'), self.vmi13_stands[0].geo_location)
         # lat 7030854.22, lon 539812.22, height 136.10

--- a/tests/domain/preprocessing_test.py
+++ b/tests/domain/preprocessing_test.py
@@ -31,7 +31,8 @@ class PreprocessingTest(unittest.TestCase):
         normal_case = TreeStratum(identifier="1-stratum", mean_diameter=17.0, mean_height=15.0, basal_area=250.0, stems_per_ha=None, biological_age=10.0, sapling_stratum=False)
         stand = ForestStand()
         stand.identifier = 'xxx'
-        stand.area_weight_factors = (1.0, 1.0)
+        stand.area = 200.0
+        stand.area_weight_factors = (1.0, 0.6)
         stand.tree_strata.append(normal_case)
         normal_case.stand = stand
         result = preprocessing.generate_reference_trees([stand], n_trees=10)
@@ -39,6 +40,7 @@ class PreprocessingTest(unittest.TestCase):
         self.assertEqual('xxx-1-tree', result[0].reference_trees[0].identifier)
         self.assertEqual(10237.96, result[0].reference_trees[0].stems_per_ha)
         self.assertEqual(1138.02, result[0].reference_trees[1].stems_per_ha)
+        self.assertEqual(120.0, result[0].area_weight)
 
     def test_determine_tree_height(self):
         stand = ForestStand()

--- a/tests/domain/preprocessing_test.py
+++ b/tests/domain/preprocessing_test.py
@@ -40,7 +40,7 @@ class PreprocessingTest(unittest.TestCase):
         self.assertEqual('xxx-1-tree', result[0].reference_trees[0].identifier)
         self.assertEqual(10237.96, result[0].reference_trees[0].stems_per_ha)
         self.assertEqual(1138.02, result[0].reference_trees[1].stems_per_ha)
-        self.assertEqual(120.0, result[0].area_weight)
+        self.assertEqual(0.0, result[0].area_weight)
 
     def test_determine_tree_height(self):
         stand = ForestStand()
@@ -66,3 +66,8 @@ class PreprocessingTest(unittest.TestCase):
         self.assertEqual(result.reference_trees[0].sapling, True)
         self.assertEqual(result.reference_trees[0].breast_height_diameter, 2)
         self.assertEqual(result.reference_trees[0].height, 0.9)
+
+    def test_scale_area_weight(self):
+        stand = ForestStand(area_weight=100.0, area_weight_factors=(0.0, 1.2))
+        result = preprocessing.scale_area_weight([stand])
+        self.assertEqual(result[0].area_weight, 120.0)


### PR DESCRIPTION
Refactored ForestBuilder to reads area and area weight as they are in source data.
- in ForestBuilder, auxiliary stands area value is initialised to zero in general.

Scaling area weights moved to distribution generation operation.
- i.e. scaling of area weight only happens for strata

Modified scaling of area factors.

closes #43 