### PR TITLE
feat: remove rsd related area conversion logic

### DIFF
--- a/lukefi/metsi/data/conversion/internal2mela.py
+++ b/lukefi/metsi/data/conversion/internal2mela.py
@@ -205,13 +205,6 @@ def stand_location_converter(target):
     return target
 
 
-def stand_area_converter(target):
-    """ in-place conversion to Mela value space for area related matters """
-    if target.is_auxiliary():
-        target.area = 0.0
-    return target
-
-
 def mela_stratum(stratum):
     """Convert a TreeStratum so that enumerated category variables are converted to Mela value space"""
     result = copy(stratum)
@@ -244,7 +237,6 @@ def mela_stand(stand):
 default_mela_tree_mappers = [species_mapper]
 default_mela_stratum_mappers = [species_mapper]
 default_mela_stand_mappers = [stand_location_converter,
-                              stand_area_converter,
                               owner_mapper, 
                               land_use_mapper, 
                               site_type_mapper, 

--- a/tests/data/internal2mela_test.py
+++ b/tests/data/internal2mela_test.py
@@ -3,7 +3,7 @@ import unittest
 from parameterized import parameterized
 from lukefi.metsi.data.model import ReferenceTree, ForestStand, TreeStratum
 from lukefi.metsi.data.conversion.internal2mela import land_use_mapper, soil_peatland_mapper, species_mapper, \
-    owner_mapper, mela_stand, stand_area_converter
+    owner_mapper, mela_stand
 from lukefi.metsi.data.enums.internal import LandUseCategory, OwnerCategory, SiteType, SoilPeatlandCategory, TreeSpecies
 from lukefi.metsi.data.enums.mela import MelaLandUseCategory, MelaOwnerCategory, MelaSoilAndPeatlandCategory, MelaTreeSpecies
 
@@ -22,7 +22,7 @@ class Internal2MelaTest(unittest.TestCase):
         self.assertEqual(MelaTreeSpecies.OTHER_DECIDUOUS, result.species)
 
     def test_stand_species_conversion(self):
-        fixture = ForestStand(geo_location=(6654200, 102598, 0.0, "EPSG:3067"), area=100.0, area_weight=100.0, auxiliary_stand=True)
+        fixture = ForestStand(geo_location=(6654200, 102598, 0.0, "EPSG:3067"), area_weight=100.0, auxiliary_stand=True)
         tree = ReferenceTree(species=TreeSpecies.SPRUCE, stand=fixture)
         stratum = TreeStratum(species=TreeSpecies.PINE, stand=fixture)
         fixture.reference_trees.append(tree)
@@ -31,7 +31,6 @@ class Internal2MelaTest(unittest.TestCase):
         self.assertEqual(MelaTreeSpecies.NORWAY_SPRUCE, result.reference_trees[0].species)
         self.assertEqual(MelaTreeSpecies.SCOTS_PINE, result.tree_strata[0].species)
         self.assertEqual((6654.2, 102.598, 0.0, "EPSG:3067"), result.geo_location)
-        self.assertEqual(0.0, result.area)
         self.assertEqual(100.0, result.area_weight)
 
     @parameterized.expand([
@@ -72,12 +71,3 @@ class Internal2MelaTest(unittest.TestCase):
             )
         result = soil_peatland_mapper(fixture)
         self.assertEqual(result.soil_peatland_category, expected)
-
-    @parameterized.expand([
-        (ForestStand(area=100.0, area_weight=100.0, auxiliary_stand=True), ForestStand(area=0.0, area_weight=100.0, auxiliary_stand=True)),
-        (ForestStand(area=100.0, area_weight=100.0, auxiliary_stand=False), ForestStand(area=100.0, area_weight=100.0, auxiliary_stand=False))
-    ])
-    def test_stand_area_converter(self, stand, expected):
-        result = stand_area_converter(stand)
-        self.assertEqual(result.area, expected.area)
-        self.assertEqual(result.area_weight, expected.area_weight)


### PR DESCRIPTION
related to #46

removed the unnecessary rsd conversion logic about the area because in #46 the area and area weight conversion was made at more general level for auxiliary stands