### PR TITLE
measuredTrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,25 +196,25 @@ configured.
 To run full pipeline from a VMI12 data source file using direct reference trees from the input data, run:
 
 ```
-python -m lukefi.metsi.app.metsi --state-format vmi12 --reference-trees -r preprocess,simulate,postprocess,export vmi12.dat sim_outdir
+python -m lukefi.metsi.app.metsi --state-format vmi12 --measured-trees -r preprocess,simulate,postprocess,export vmi12.dat sim_outdir
 ```
 
 To run full pipeline from a VMI13 data source file using direct reference trees from the input data, run:
 
 ```
-python -m lukefi.metsi.app.metsi --state-format vmi13 --reference-trees -r preprocess,simulate,postprocess,export vmi13.dat sim_outdir
+python -m lukefi.metsi.app.metsi --state-format vmi13 --measured-trees -r preprocess,simulate,postprocess,export vmi13.dat sim_outdir
 ```
 
 To run full pipeline from a Forest Centre .xml source file, run:
 
 ```
-python -m lukefi.metsi.app.metsi --state-format forest_centre --reference-trees -r preprocess,simulate,postprocess,export forest_centre.xml sim_outdir
+python -m lukefi.metsi.app.metsi --state-format forest_centre --measured-trees -r preprocess,simulate,postprocess,export forest_centre.xml sim_outdir
 ```
 
 To run full pipeline from a Forest Centre .gpkg source file, run:
 
 ```
-python -m lukefi.metsi.app.metsi --state-format geopackage --reference-trees -r preprocess,simulate,postprocess,export geopackage.gpkg sim_outdir
+python -m lukefi.metsi.app.metsi --state-format geopackage --measured-trees -r preprocess,simulate,postprocess,export geopackage.gpkg sim_outdir
 ```
 
 To run full pipeline from a FDM formatted data from csv (or json or pickle with replacement below), run:
@@ -722,7 +722,7 @@ A run is declared in the YAML file `control.yaml`.
         1. `fdm` is the standard Forest Data Model.
         2. `vmi12` and `vmi13` denote the VMI data format and container.
         3. `forest_centre` denotes the Forest Centre XML data format and container.
-        4. `geopackage` denotes the Forest Centre GPKG data format and container.
+        4. `geo_package` denotes the Forest Centre GPKG data format and container.
     2. `state_input_container` is the file type for `fdm` data format. This may be `csv`, `pickle` or `json`.
     3. `preprocessing_output_container` is the file type for outputting the `fdm` formatted state of computational units
        after preprocessing operations. This may be `csv`, `pickle` or `json` or commented out for no output.
@@ -731,8 +731,9 @@ A run is declared in the YAML file `control.yaml`.
     5. `derived_data_output_container` is the file type for outputting derived data during and after the simulation.
        This may be `pickle` or `json` or commented out for no output.
     6. `strategy` is the simulation event tree formation strategy. Can be `partial` or `full`.
-    7. `reference_trees` instructs the `vmi12` and `vmi13` data converters to choose either reference trees or tree
-       strata from the source. `True` or `False`.
+    7. `measured_trees` instructs the `vmi12` and `vmi13` data converters to choose reference trees from the source.
+      `True` or `False`.
+    8. `strata` instructs the `vmi12` and `vmi13` data converters strata from the source. `True` or `False`.
     8. `strata_origin` instructs the `forest_centre` converter to choose only strata with certain origin to the
        result. `1`, `2` or `3`.
     9. `multiprocessing` instructs the application to parallelizes the computation to available CPU cores in the

--- a/README.md
+++ b/README.md
@@ -208,13 +208,13 @@ python -m lukefi.metsi.app.metsi --state-format vmi13 --measured-trees -r prepro
 To run full pipeline from a Forest Centre .xml source file, run:
 
 ```
-python -m lukefi.metsi.app.metsi --state-format forest_centre --measured-trees -r preprocess,simulate,postprocess,export forest_centre.xml sim_outdir
+python -m lukefi.metsi.app.metsi --state-format forest_centre -r preprocess,simulate,postprocess,export forest_centre.xml sim_outdir
 ```
 
 To run full pipeline from a Forest Centre .gpkg source file, run:
 
 ```
-python -m lukefi.metsi.app.metsi --state-format geopackage --measured-trees -r preprocess,simulate,postprocess,export geopackage.gpkg sim_outdir
+python -m lukefi.metsi.app.metsi --state-format geopackage -r preprocess,simulate,postprocess,export geopackage.gpkg sim_outdir
 ```
 
 To run full pipeline from a FDM formatted data from csv (or json or pickle with replacement below), run:

--- a/lukefi/metsi/app/app_io.py
+++ b/lukefi/metsi/app/app_io.py
@@ -23,7 +23,7 @@ class MetsiConfiguration(SimpleNamespace):
     derived_data_output_container = None
     formation_strategy = "partial"
     evaluation_strategy = "depth"
-    reference_trees = False
+    measured_trees = False
     strata = True
     strata_origin = "1"
 
@@ -141,9 +141,9 @@ def parse_cli_arguments(args: list[str]):
                         choices=['pickle', 'json'],
                         type=str,
                         help='Container format of derived data result file: \'pickle\' (default), \'json\'')
-    parser.add_argument('--reference-trees',
+    parser.add_argument('--measured-trees',
                         action=argparse.BooleanOptionalAction,
-                        help="Include reference trees from VMI data source.")
+                        help="Include measured trees from VMI data source.")
     parser.add_argument('--strata',
                         action=argparse.BooleanOptionalAction,
                         help="Include strata from VMI data source.")

--- a/lukefi/metsi/app/file_io.py
+++ b/lukefi/metsi/app/file_io.py
@@ -119,7 +119,7 @@ def read_stands_from_file(app_config: MetsiConfiguration) -> StandList:
         return external_reader(
             app_config.state_format,
             strata=app_config.strata,
-            reference_trees=app_config.reference_trees,
+            measured_trees=app_config.measured_trees,
             strata_origin=app_config.strata_origin)(app_config.input_path)
     else:
         raise Exception(f"Unsupported state format '{app_config.state_format}'")

--- a/lukefi/metsi/data/formats/ForestBuilder.py
+++ b/lukefi/metsi/data/formats/ForestBuilder.py
@@ -226,7 +226,7 @@ class VMI12Builder(VMIBuilder):
                 stratum.stand = stand
                 stand.tree_strata.append(stratum)
 
-        if self.builder_flags['reference_trees']:
+        if self.builder_flags['measured_trees']:
             for i, row in enumerate(self.reference_trees):
                 tree = self.convert_tree_entry(VMI12TreeIndices, row)
                 stand_id = vmi_util.generate_stand_identifier(row, VMI12StandIndices)
@@ -314,7 +314,7 @@ class VMI13Builder(VMIBuilder):
                 stratum.stand = stand
                 stand.tree_strata.append(stratum)
 
-        if self.builder_flags['reference_trees']:
+        if self.builder_flags['measured_trees']:
             for i, row in enumerate(self.reference_trees):
                 tree = self.convert_tree_entry(VMI13TreeIndices, row)
                 stand_id = vmi_util.generate_stand_identifier(row, VMI13StandIndices)

--- a/tests/app/app_io_test.py
+++ b/tests/app/app_io_test.py
@@ -11,7 +11,7 @@ class TestAppIO(unittest.TestCase):
             'state_format': 'vmi12',
             'state_output_container': 'pickle'
         }
-        args = ['input.pickle', 'control.yaml', 'output2', '-s', 'partial', '--state-format', 'fdm', '--reference-trees', '--strata-origin', '2']
+        args = ['input.pickle', 'control.yaml', 'output2', '-s', 'partial', '--state-format', 'fdm', '--measured-trees', '--strata-origin', '2']
         result = set_default_arguments(aio.parse_cli_arguments(args), default_io_arguments)
         self.assertEqual(None, result.preprocessing_output_container)
         self.assertEqual(None, result.state_input_container)
@@ -19,7 +19,7 @@ class TestAppIO(unittest.TestCase):
         self.assertEqual('fdm', result.state_format)
 
     def test_sim_cli_arguments(self):
-        args = ['input.pickle', 'output2', 'control.yaml', '-f', 'partial', '-e', 'depth', '--state-format', 'fdm', '--reference-trees', '--strata-origin', '2']
+        args = ['input.pickle', 'output2', 'control.yaml', '-f', 'partial', '-e', 'depth', '--state-format', 'fdm', '--measured-trees', '--strata-origin', '2']
         result = aio.parse_cli_arguments(args)
         self.assertEqual(16, len(result.__dict__.keys()))
         self.assertEqual('input.pickle', result.input_path)
@@ -30,7 +30,7 @@ class TestAppIO(unittest.TestCase):
         self.assertEqual('fdm', result.state_format)
         self.assertEqual(None, result.state_input_container)
         self.assertEqual(None, result.state_output_container)
-        self.assertEqual(True, result.reference_trees)
+        self.assertEqual(True, result.measured_trees)
         self.assertEqual("2", result.strata_origin)
 
     def test_run_modes(self):

--- a/tests/data/forest_builder_run_test.py
+++ b/tests/data/forest_builder_run_test.py
@@ -17,7 +17,7 @@ class TestForestBuilderRun(unittest.TestCase):
     def test_run_smk_forest_builder_build(self):
         assertion = ('SMK_source.xml', 2)
         reference_file = Path('tests', 'data', 'resources', assertion[0])
-        list_of_stands = ForestCentreBuilder({"strata_origin": "1", "reference_trees": False},
+        list_of_stands = ForestCentreBuilder({"strata_origin": "1", "measured_trees": False},
                                              xml_file_reader(reference_file)).build()
         result = len(list_of_stands)
         self.assertEqual(result, assertion[1])
@@ -26,7 +26,7 @@ class TestForestBuilderRun(unittest.TestCase):
     def test_run_vmi12_forest_builder_build(self):
         assertion = ('VMI12_source_mini.dat', 4)
         reference_file = Path('tests', 'data', 'resources', assertion[0])
-        list_of_stands = VMI12Builder({"reference_trees": False, "strata": True}, vmi_file_reader(reference_file)).build()
+        list_of_stands = VMI12Builder({"measured_trees": False, "strata": True}, vmi_file_reader(reference_file)).build()
         result = len(list_of_stands)
         self.assertEqual(result, assertion[1])
 
@@ -34,7 +34,7 @@ class TestForestBuilderRun(unittest.TestCase):
     def test_run_vmi13_forest_builder_build(self):
         assertion = ('VMI13_source_mini.dat', 3)
         reference_file = Path('tests', 'data', 'resources', assertion[0])
-        list_of_stands = VMI13Builder({"reference_trees": False, "strata": True}, vmi_file_reader(reference_file)).build()
+        list_of_stands = VMI13Builder({"measured_trees": False, "strata": True}, vmi_file_reader(reference_file)).build()
         result = len(list_of_stands)
         self.assertEqual(result, assertion[1])
 

--- a/tests/data/test_util.py
+++ b/tests/data/test_util.py
@@ -24,4 +24,4 @@ vmi13_data = [
     '6 U 1  99  99 99 8   6 0 20181102 258  7  3  0  23 V2  3  53  6  1  4  35  4  .  .   .  .  .  .   .  .  .  .   .  .  .  .   .  .  .  .   .  .  .  .   .  .  .  .   .  .  .  .   .  . .    .',
     ""
 ]
-vmi13_builder: VMIBuilder = VMI13Builder({ 'reference_trees': True, 'strata': True}, vmi13_data)
+vmi13_builder: VMIBuilder = VMI13Builder({ 'measured_trees': True, 'strata': True}, vmi13_data)

--- a/tests/data/vmi_builder_test.py
+++ b/tests/data/vmi_builder_test.py
@@ -7,7 +7,7 @@ from lukefi.metsi.data.enums.internal import *
 
 class TestForestBuilder(unittest.TestCase):
 
-    default_builder_flags = {"reference_trees": True, "strata": True}
+    default_builder_flags = {"measured_trees": True, "strata": True}
 
     @classmethod
     def vmi12_builder(cls, vmi_builder_flags: dict = default_builder_flags) -> VMI12Builder:
@@ -56,8 +56,8 @@ class TestForestBuilder(unittest.TestCase):
         cls.vmi12_stands = cls.vmi12_built()
         cls.vmi13_stands = cls.vmi13_built()
 
-        cls.vmi12_stands_ref_trees_false = cls.vmi12_built({'reference_trees': False, 'strata': True})
-        cls.vmi13_stands_ref_trees_false = cls.vmi13_built({'reference_trees': False, 'strata': True})
+        cls.vmi12_stands_ref_trees_false = cls.vmi12_built({'measured_trees': False, 'strata': True})
+        cls.vmi13_stands_ref_trees_false = cls.vmi13_built({'measured_trees': False, 'strata': True})
 
 
     def test_vmi12_init(self):


### PR DESCRIPTION
Shift `--reference-trees` flag into `--measured-trees` flag in CLI.
Also updated README.md to correspond this refactorisation.

closes #38 