### PR TITLE
fix: Strip tuhon_ilmiasu in ForestBuilder

### DIFF
--- a/lukefi/metsi/data/formats/ForestBuilder.py
+++ b/lukefi/metsi/data/formats/ForestBuilder.py
@@ -104,7 +104,7 @@ class VMIBuilder(ForestBuilder):
         result.management_category = vmi_util.determine_tree_management_category(data_row[indices.latvuskerros])
         result.storey = vmi_util.determine_storey_for_tree(data_row[indices.latvuskerros])
         result.tree_type = vmi_util.determine_tree_type(data_row[indices.tree_type])
-        result.tuhon_ilmiasu = None if data_row[indices.tuhon_ilmiasu] == "  " else data_row[indices.tuhon_ilmiasu]
+        result.tuhon_ilmiasu = None if data_row[indices.tuhon_ilmiasu] == "  " else data_row[indices.tuhon_ilmiasu].strip()
         return result
 
     def convert_stratum_entry(self, indices: VMI12StratumIndices or VMI13StratumIndices,

--- a/lukefi/metsi/data/formats/ForestBuilder.py
+++ b/lukefi/metsi/data/formats/ForestBuilder.py
@@ -104,7 +104,7 @@ class VMIBuilder(ForestBuilder):
         result.management_category = vmi_util.determine_tree_management_category(data_row[indices.latvuskerros])
         result.storey = vmi_util.determine_storey_for_tree(data_row[indices.latvuskerros])
         result.tree_type = vmi_util.determine_tree_type(data_row[indices.tree_type])
-        result.tuhon_ilmiasu = None if data_row[indices.tuhon_ilmiasu] == "  " else data_row[indices.tuhon_ilmiasu].strip()
+        result.tuhon_ilmiasu = None if data_row[indices.tuhon_ilmiasu] in ('  ',' ', '.', '') else data_row[indices.tuhon_ilmiasu].strip()
         return result
 
     def convert_stratum_entry(self, indices: VMI12StratumIndices or VMI13StratumIndices,

--- a/lukefi/metsi/forestry/preprocessing/tree_generation_lm.py
+++ b/lukefi/metsi/forestry/preprocessing/tree_generation_lm.py
@@ -38,7 +38,7 @@ def tree_generation_lm(stratum: TreeStratum, degree_days: float, stand_basal_are
 
     tree_data = {
         'lpm': robjects.FloatVector([tree.breast_height_diameter or robjects.NA_Real for tree in source_trees]),
-        'height': robjects.FloatVector([robjects.NA_Real if tree.tuhon_ilmiasu.strip() in ('2', '61', '62', '71', '72') \
+        'height': robjects.FloatVector([robjects.NA_Real if tree.tuhon_ilmiasu in ('2', '61', '62', '71', '72') \
             else (tree.measured_height or robjects.NA_Real) for tree in source_trees]),
         'lkm': robjects.FloatVector([tree.stems_per_ha or robjects.NA_Real for tree in source_trees])
     }

--- a/tests/data/vmi_builder_test.py
+++ b/tests/data/vmi_builder_test.py
@@ -445,6 +445,7 @@ class TestForestBuilder(unittest.TestCase):
         self.assertEqual(1, tree.management_category)
         self.assertEqual(Storey.DOMINANT, tree.storey)
         self.assertEqual('V', tree.tree_type)
+        self.assertEqual(None, tree.tuhon_ilmiasu)
 
     def test_vmi13_strata(self):
         self.assertEqual(0, len(self.vmi13_stands_ref_trees_false[0].tree_strata))


### PR DESCRIPTION
tuhon_ilmiasu was stripped when generating the reference trees, which caused the program to crash if tuhon_ilmiasu was None. Fixed it by stripping tuhon_ilmiasu in ForestBuilder  instead of  the reference tree generation.