### PR TITLE
Refactor forest centre builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ python -m lukefi.metsi.app.metsi --state-format xml --reference-trees -r preproc
 To run full pipeline from a Forest Centre .gpkg source file, run:
 
 ```
-python -m lukefi.metsi.app.metsi --state-format geopackage --reference-trees -r preprocess,simulate,postprocess,export geopackage.gpkg sim_outdir
+python -m lukefi.metsi.app.metsi --state-format gpkg --reference-trees -r preprocess,simulate,postprocess,export geopackage.gpkg sim_outdir
 ```
 
 To run full pipeline from a FDM formatted data from csv (or json or pickle with replacement below), run:
@@ -722,7 +722,7 @@ A run is declared in the YAML file `control.yaml`.
         1. `fdm` is the standard Forest Data Model.
         2. `vmi12` and `vmi13` denote the VMI data format and container.
         3. `xml` denotes the Forest Centre XML data format and container.
-        4. `geopackage` denotes the Forest Centre GPKG data format and container.
+        4. `gpkg` denotes the Forest Centre GPKG data format and container.
     2. `state_input_container` is the file type for `fdm` data format. This may be `csv`, `pickle` or `json`.
     3. `preprocessing_output_container` is the file type for outputting the `fdm` formatted state of computational units
        after preprocessing operations. This may be `csv`, `pickle` or `json` or commented out for no output.

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ python -m lukefi.metsi.app.metsi --state-format vmi13 --reference-trees -r prepr
 To run full pipeline from a Forest Centre .xml source file, run:
 
 ```
-python -m lukefi.metsi.app.metsi --state-format forest_centre --reference-trees -r preprocess,simulate,postprocess,export forest_centre.xml sim_outdir
+python -m lukefi.metsi.app.metsi --state-format xml --reference-trees -r preprocess,simulate,postprocess,export forest_centre.xml sim_outdir
 ```
 
 To run full pipeline from a Forest Centre .gpkg source file, run:
@@ -721,7 +721,7 @@ A run is declared in the YAML file `control.yaml`.
     1. `state_format` specifies the data format of the input computational units
         1. `fdm` is the standard Forest Data Model.
         2. `vmi12` and `vmi13` denote the VMI data format and container.
-        3. `forest_centre` denotes the Forest Centre XML data format and container.
+        3. `xml` denotes the Forest Centre XML data format and container.
         4. `geopackage` denotes the Forest Centre GPKG data format and container.
     2. `state_input_container` is the file type for `fdm` data format. This may be `csv`, `pickle` or `json`.
     3. `preprocessing_output_container` is the file type for outputting the `fdm` formatted state of computational units
@@ -733,7 +733,7 @@ A run is declared in the YAML file `control.yaml`.
     6. `strategy` is the simulation event tree formation strategy. Can be `partial` or `full`.
     7. `reference_trees` instructs the `vmi12` and `vmi13` data converters to choose either reference trees or tree
        strata from the source. `True` or `False`.
-    8. `strata_origin` instructs the `forest_centre` converter to choose only strata with certain origin to the
+    8. `strata_origin` instructs a forest centre converter to choose only strata with certain origin to the
        result. `1`, `2` or `3`.
     9. `multiprocessing` instructs the application to parallelizes the computation to available CPU cores in the
        system. `True` or `False`.

--- a/control.yaml
+++ b/control.yaml
@@ -1,6 +1,6 @@
 #Application configuration values. Can be overriden by CLI arguments. May be commented out for None or default from Mela2Configuration.
 app_configuration:
-  state_format: fdm #options: fdm, vmi12, vmi13, forest_centre, geopackage
+  state_format: fdm #options: fdm, vmi12, vmi13, xml, geopackage
   state_input_container: csv #Only relevant with fdm state_format. Options: pickle, json
   #preprocessing_output_container: csv #options: pickle, json, csv, null, rsd (special case not usable as input container)
   #state_output_container: csv #options: pickle, json, csv, null

--- a/control.yaml
+++ b/control.yaml
@@ -1,6 +1,6 @@
 #Application configuration values. Can be overriden by CLI arguments. May be commented out for None or default from Mela2Configuration.
 app_configuration:
-  state_format: fdm #options: fdm, vmi12, vmi13, xml, geopackage
+  state_format: fdm #options: fdm, vmi12, vmi13, xml, gpkg
   state_input_container: csv #Only relevant with fdm state_format. Options: pickle, json
   #preprocessing_output_container: csv #options: pickle, json, csv, null, rsd (special case not usable as input container)
   #state_output_container: csv #options: pickle, json, csv, null

--- a/examples/conversion.yaml
+++ b/examples/conversion.yaml
@@ -2,7 +2,7 @@
 
 #Application configuration values. Can be overriden by CLI arguments. May be commented out for None or default from Mela2Configuration.
 app_configuration:
-  state_format: fdm #options: fdm, vmi12, vmi13, forest_centre
+  state_format: fdm #options: fdm, vmi12, vmi13, xml
   state_input_container: csv #Only relevant with fdm state_format. Options: pickle, json
   preprocessing_output_container: csv #options: pickle, json, csv, null, rsd (special case not usable as input container)
   #state_output_container: csv #options: pickle, json, csv, null

--- a/examples/export/control.yaml
+++ b/examples/export/control.yaml
@@ -1,6 +1,6 @@
 #Application configuration values. Can be overriden by CLI arguments. May be commented out for None or default from Mela2Configuration.
 app_configuration:
-  state_format: fdm #options: fdm, vmi12, vmi13, forest_centre
+  state_format: fdm #options: fdm, vmi12, vmi13, xml
   state_input_container: csv #Only relevant with fdm state_format. Options: pickle, json
   #preprocessing_output_container: csv #options: pickle, json, csv, null, rsd (special case not usable as input container)
   #state_output_container: csv #options: pickle, json, csv, null

--- a/examples/lm_tree_generation.yaml
+++ b/examples/lm_tree_generation.yaml
@@ -2,7 +2,7 @@
 
 #Application configuration values. Can be overriden by CLI arguments. May be commented out for None or default from Mela2Configuration.
 app_configuration:
-  state_format: vmi12 #options: fdm, vmi12, vmi13, forest_centre
+  state_format: vmi12 #options: fdm, vmi12, vmi13, xml
   preprocessing_output_container: csv #options: pickle, json, csv, null, rsd (special case not usable as input container)
   run_modes: preprocess
 

--- a/examples/weibull_tree_generation.yaml
+++ b/examples/weibull_tree_generation.yaml
@@ -2,7 +2,7 @@
 
 #Application configuration values. Can be overriden by CLI arguments. May be commented out for None or default from Mela2Configuration.
 app_configuration:
-  state_format: vmi12 #options: fdm, vmi12, vmi13, forest_centre
+  state_format: vmi12 #options: fdm, vmi12, vmi13, xml
   preprocessing_output_container: csv #options: pickle, json, csv, null, rsd (special case not usable as input container)
   run_modes: preprocess
 

--- a/lukefi/metsi/app/app_io.py
+++ b/lukefi/metsi/app/app_io.py
@@ -122,9 +122,9 @@ def parse_cli_arguments(args: list[str]):
                         type=str,
                         help='Simulation event tree evaluation strategy: \'depth\' (default), \'chains\'')
     parser.add_argument('--state-format',
-                        choices=['fdm', 'vmi12', 'vmi13', 'xml', 'geo_package'],
+                        choices=['fdm', 'vmi12', 'vmi13', 'xml', 'gpkg'],
                         type=str,
-                        help='Data format of the state input file: fdm (default), vmi12, vmi13, xml, geopackage')
+                        help='Data format of the state input file: fdm (default), vmi12, vmi13, xml, gpkg')
     parser.add_argument('--state-input-container',
                         choices=['pickle', 'json', 'csv'],
                         type=str,

--- a/lukefi/metsi/app/app_io.py
+++ b/lukefi/metsi/app/app_io.py
@@ -122,9 +122,9 @@ def parse_cli_arguments(args: list[str]):
                         type=str,
                         help='Simulation event tree evaluation strategy: \'depth\' (default), \'chains\'')
     parser.add_argument('--state-format',
-                        choices=['fdm', 'vmi12', 'vmi13', 'forest_centre', 'geo_package'],
+                        choices=['fdm', 'vmi12', 'vmi13', 'xml', 'geo_package'],
                         type=str,
-                        help='Data format of the state input file: fdm (default), vmi12, vmi13, forest_centre, geopackage')
+                        help='Data format of the state input file: fdm (default), vmi12, vmi13, xml, geopackage')
     parser.add_argument('--state-input-container',
                         choices=['pickle', 'json', 'csv'],
                         type=str,

--- a/lukefi/metsi/app/file_io.py
+++ b/lukefi/metsi/app/file_io.py
@@ -6,7 +6,7 @@ import jsonpickle
 from typing import Any, Optional
 from collections.abc import Iterator, Callable
 import yaml
-from lukefi.metsi.data.formats.ForestBuilder import VMI13Builder, VMI12Builder, ForestCentreBuilder, GeoPackageBuilder
+from lukefi.metsi.data.formats.ForestBuilder import VMI13Builder, VMI12Builder, XMLBuilder, GeoPackageBuilder
 from lukefi.metsi.data.formats.io_utils import stands_to_csv_content, csv_content_to_stands, stands_to_rsd_content
 from lukefi.metsi.app.app_io import MetsiConfiguration
 from lukefi.metsi.app.app_types import SimResults, ForestOpPayload
@@ -99,8 +99,8 @@ def external_reader(state_format: str, **builder_flags) -> StandReader:
         return lambda path: VMI13Builder(builder_flags, vmi_file_reader(path)).build()
     elif state_format == "vmi12":
         return lambda path: VMI12Builder(builder_flags, vmi_file_reader(path)).build()
-    elif state_format == "forest_centre":
-        return lambda path: ForestCentreBuilder(builder_flags, xml_file_reader(path)).build()
+    elif state_format == "xml":
+        return lambda path: XMLBuilder(builder_flags, xml_file_reader(path)).build()
     elif state_format == "geo_package":
         return lambda path: GeoPackageBuilder(builder_flags, path).build()
 
@@ -115,7 +115,7 @@ def read_stands_from_file(app_config: MetsiConfiguration) -> StandList:
     """
     if app_config.state_format == "fdm":
         return fdm_reader(app_config.state_input_container)(app_config.input_path)
-    elif app_config.state_format in ("vmi13", "vmi12", "forest_centre", "geo_package"):
+    elif app_config.state_format in ("vmi13", "vmi12", "xml", "geo_package"):
         return external_reader(
             app_config.state_format,
             strata=app_config.strata,

--- a/lukefi/metsi/app/file_io.py
+++ b/lukefi/metsi/app/file_io.py
@@ -101,7 +101,7 @@ def external_reader(state_format: str, **builder_flags) -> StandReader:
         return lambda path: VMI12Builder(builder_flags, vmi_file_reader(path)).build()
     elif state_format == "xml":
         return lambda path: XMLBuilder(builder_flags, xml_file_reader(path)).build()
-    elif state_format == "geo_package":
+    elif state_format == "gpkg":
         return lambda path: GeoPackageBuilder(builder_flags, path).build()
 
 
@@ -115,7 +115,7 @@ def read_stands_from_file(app_config: MetsiConfiguration) -> StandList:
     """
     if app_config.state_format == "fdm":
         return fdm_reader(app_config.state_input_container)(app_config.input_path)
-    elif app_config.state_format in ("vmi13", "vmi12", "xml", "geo_package"):
+    elif app_config.state_format in ("vmi13", "vmi12", "xml", "gpkg"):
         return external_reader(
             app_config.state_format,
             strata=app_config.strata,

--- a/lukefi/metsi/data/formats/ForestBuilder.py
+++ b/lukefi/metsi/data/formats/ForestBuilder.py
@@ -325,6 +325,7 @@ class VMI13Builder(VMIBuilder):
         return list(result.values())
 
 class ForestCentreBuilder(ForestBuilder):
+    ''' Base class for building a forest data model from Forest Centre (Suomen Metsakeskus) source '''
 
     @abstractmethod
     def build(self) -> list[ForestStand]:

--- a/lukefi/metsi/data/formats/ForestBuilder.py
+++ b/lukefi/metsi/data/formats/ForestBuilder.py
@@ -332,12 +332,12 @@ class ForestCentreBuilder(ForestBuilder):
 
 
     @abstractmethod
-    def convert_stand_entry(self):
+    def convert_stand_entry(self, entry) -> ForestStand:
         ...
 
 
     @abstractmethod
-    def convert_stratum_entry(self):
+    def convert_stratum_entry(self, entry) -> TreeStratum:
         ...
 
 class XMLBuilder(ForestCentreBuilder):

--- a/lukefi/metsi/data/formats/ForestBuilder.py
+++ b/lukefi/metsi/data/formats/ForestBuilder.py
@@ -324,12 +324,7 @@ class VMI13Builder(VMIBuilder):
 
         return list(result.values())
 
-class XMLBuilder(ForestBuilder):
-
-    def __init__(self, builder_flags: dict, data: str):
-        self.root: ET.Element = ET.fromstring(data)
-        self.builder_flags = builder_flags
-
+class ForestCentreBuilder(ForestBuilder):
 
     @abstractmethod
     def build(self) -> list[ForestStand]:
@@ -345,14 +340,15 @@ class XMLBuilder(ForestBuilder):
     def convert_stratum_entry(self):
         ...
 
-class ForestCentreBuilder(XMLBuilder):
+class XMLBuilder(ForestCentreBuilder):
 
     xpath_strata = './ts:TreeStandData/ts:TreeStandDataDate[@type="{}"]/tst:TreeStrata/tst:TreeStratum'
     xpath_stand = "st:Stands/st:Stand"
 
 
     def __init__(self, builder_flags: dict, data: str):
-        super().__init__(builder_flags, data)
+        self.root: ET.Element = ET.fromstring(data)
+        self.builder_flags = builder_flags
         self.xpath_strata = self.xpath_strata.format(builder_flags['strata_origin'])
 
 
@@ -469,8 +465,8 @@ class ForestCentreBuilder(XMLBuilder):
         return stands
 
 
-class GeoPackageBuilder(ForestBuilder):
-    """ ForestBuilder class for geopackage format spesification """
+class GeoPackageBuilder(ForestCentreBuilder):
+    """ ForestBuilder for geopackage format spesification """
     stands: DataFrame = None
     strata: DataFrame = None
     type_value = None

--- a/tests/app/file_io_test.py
+++ b/tests/app/file_io_test.py
@@ -171,6 +171,15 @@ class TestFileReading(unittest.TestCase):
         stands = lukefi.metsi.app.file_io.read_stands_from_file(config)
         self.assertEqual(len(stands), 2)
 
+    def test_read_stands_from_gpkg_file(self):
+        config = MetsiConfiguration(
+            input_path="tests/data/resources/SMK_source.gpkg",
+            state_format="gpkg",
+            state_input_container=""
+        )
+        stands = lukefi.metsi.app.file_io.read_stands_from_file(config)
+        self.assertEqual(len(stands), 9)
+
     def test_read_schedule_payload_from_directory(self):
         dir = Path("tests/resources/file_io_test/testing_output_directory/3/0")
         result = lukefi.metsi.app.file_io.read_schedule_payload_from_directory(dir)

--- a/tests/app/file_io_test.py
+++ b/tests/app/file_io_test.py
@@ -165,7 +165,7 @@ class TestFileReading(unittest.TestCase):
     def test_read_stands_from_xml_file(self):
         config = MetsiConfiguration(
             input_path="tests/resources/file_io_test/forest_centre.xml",
-            state_format="forest_centre",
+            state_format="xml",
             state_input_container=""
         )
         stands = lukefi.metsi.app.file_io.read_stands_from_file(config)

--- a/tests/app/main_test.py
+++ b/tests/app/main_test.py
@@ -16,7 +16,7 @@ class MainTest(unittest.TestCase):
         sys.argv = [
             'metsi',
             '--state-format',
-            'forest_centre',
+            'xml',
             '--preprocessing-output-container',
             'csv',
             '-r',

--- a/tests/data/forest_builder_run_test.py
+++ b/tests/data/forest_builder_run_test.py
@@ -1,5 +1,5 @@
 import unittest
-from lukefi.metsi.data.formats.ForestBuilder import VMI12Builder, VMI13Builder, ForestCentreBuilder, GeoPackageBuilder
+from lukefi.metsi.data.formats.ForestBuilder import VMI12Builder, VMI13Builder, XMLBuilder, GeoPackageBuilder
 from pathlib import Path
 
 
@@ -17,7 +17,7 @@ class TestForestBuilderRun(unittest.TestCase):
     def test_run_smk_forest_builder_build(self):
         assertion = ('SMK_source.xml', 2)
         reference_file = Path('tests', 'data', 'resources', assertion[0])
-        list_of_stands = ForestCentreBuilder({"strata_origin": "1", "reference_trees": False},
+        list_of_stands = XMLBuilder({"strata_origin": "1", "reference_trees": False},
                                              xml_file_reader(reference_file)).build()
         result = len(list_of_stands)
         self.assertEqual(result, assertion[1])

--- a/tests/data/smk_builder_test.py
+++ b/tests/data/smk_builder_test.py
@@ -1,21 +1,21 @@
 import unittest
 import os
 from functools import reduce
-from lukefi.metsi.data.formats.ForestBuilder import ForestCentreBuilder, GeoPackageBuilder
+from lukefi.metsi.data.formats.ForestBuilder import XMLBuilder, GeoPackageBuilder
 from lukefi.metsi.data.enums.internal import *
 
 builder_flags = {
     'strata_origin': '1'
 }
 
-class TestForestCentreBuilder(unittest.TestCase):
+class TestXMLBuilder(unittest.TestCase):
     
     xml_data = 'SMK_source.xml'
     absolute_resource_path = os.path.join(os.getcwd(), 'tests', 'data', 'resources', xml_data)
 
     with open(absolute_resource_path, 'r', encoding='utf-8') as f:
         xml_string = f.read()
-    smk_builder = ForestCentreBuilder(builder_flags, xml_string)
+    smk_builder = XMLBuilder(builder_flags, xml_string)
     smk_stands = smk_builder.build()
 
     def test_individual_smk_build_with_different_strata_origins(self):
@@ -25,7 +25,7 @@ class TestForestCentreBuilder(unittest.TestCase):
             (None, 0)
         ]
         for i in assertions:
-            smk_builder = ForestCentreBuilder(
+            smk_builder = XMLBuilder(
                 {
                     'strata_origin': i[0]
                 },


### PR DESCRIPTION
Conformed FC (Forest Centre/Suomen Metsäkeskus) class hierarchy in ForestBuilder module.

In CLI for `--state-format` flag  the value was changed from:
- `forest_centre` to `xml`
- `geo_package` to `gpkg`