### PR TITLE
fix: IntEnum.__str__ compatibility

### DIFF
--- a/lukefi/metsi/data/enums/internal.py
+++ b/lukefi/metsi/data/enums/internal.py
@@ -1,7 +1,12 @@
 from enum import IntEnum
 
 
-class TreeSpecies(IntEnum):
+class MetsiEnum(IntEnum):
+
+    def __str__(self):
+        return self.__int__().__str__()
+
+class TreeSpecies(MetsiEnum):
     """This list is formed by combining VMI and Forest centre species 
     and listing all the distinct ones. UNKNOWN (38) is not part of either list, 
     but can be assigned to in case the source data species is unexpected."""
@@ -97,7 +102,7 @@ CONIFEROUS_SPECIES = [
 ]
 
 
-class LandUseCategory(IntEnum):
+class LandUseCategory(MetsiEnum):
     FOREST = 1
     SCRUB_LAND = 2
     WASTE_LAND = 3
@@ -113,7 +118,7 @@ class LandUseCategory(IntEnum):
     WATER_BODY = 13
 
 
-class OwnerCategory(IntEnum):
+class OwnerCategory(MetsiEnum):
     UNKNOWN = 0
     PRIVATE = 1
     FOREST_INDUSTRY = 2
@@ -127,14 +132,14 @@ class OwnerCategory(IntEnum):
     UNDIVIDED = 10
 
 
-class SoilPeatlandCategory(IntEnum):
+class SoilPeatlandCategory(MetsiEnum):
     MINERAL_SOIL = 1 # kangas
     SPRUCE_MIRE = 2 # korpi
     PINE_MIRE = 3 # räme
     TREELESS_MIRE = 4 # avosuo. Conversion to MELA's Neva or Letto is made with siteType
 
 
-class SiteType(IntEnum):
+class SiteType(MetsiEnum):
     VERY_RICH_SITE = 1
     RICH_SITE = 2
     DAMP_SITE = 3
@@ -147,7 +152,7 @@ class SiteType(IntEnum):
     LAKIMETSA_TAI_TUNTURIHAVUMETSA = 10
 
 
-class DrainageCategory(IntEnum):
+class DrainageCategory(MetsiEnum):
     UNDRAINED_MINERAL_SOIL_OR_MIRE = 1
     UNDRAINED_MINERAL_SOIL = 2
     MINERAL_SOIL_TURNED_MIRE = 3
@@ -157,7 +162,7 @@ class DrainageCategory(IntEnum):
     TRANSFORMING_MIRE = 7
     TRANSFORMED_MIRE = 8
 
-class Storey(IntEnum):
+class Storey(MetsiEnum):
     INDETERMINATE = 0
     DOMINANT = 1
     UNDER = 2

--- a/lukefi/metsi/data/formats/util.py
+++ b/lukefi/metsi/data/formats/util.py
@@ -46,7 +46,7 @@ def convert_str_to_type(_class: type, value: str, property_name: str):
     if property_type in (str, Optional[str]):
         return str(value)
     if isinstance(property_type.__args__[0], EnumMeta):
-        return property_type.__args__[0][value.split('.')[1]]
+        return property_type.__args__[0](int(value))
 
     if type(value) == tuple:
         #stand.area_weight_factors

--- a/lukefi/metsi/data/model.py
+++ b/lukefi/metsi/data/model.py
@@ -196,7 +196,7 @@ class TreeStratum():
 
         result = cls()
         result.identifier = conv(row[1], "identifier")
-        result.species = TreeSpecies[row[2].split(".")[1]]
+        result.species = TreeSpecies(int(row[2]))
         result.origin = conv(row[3], "origin")
         result.stems_per_ha = conv(row[4], "stems_per_ha")
         result.mean_diameter = conv(row[5], "mean_diameter")
@@ -213,7 +213,7 @@ class TreeStratum():
         result.management_category = conv(row[18], "management_category")
         result.sapling_stems_per_ha = conv(row[19], "sapling_stems_per_ha")
         result.sapling_stratum = conv(row[20], "sapling_stratum")
-        result.storey = Storey[row[21].split(".")[1]] if row[21] != "None" else None
+        result.storey = Storey(int(row[21])) if row[21] != "None" else None
         return result
 
 @dataclass
@@ -228,7 +228,7 @@ class ReferenceTree():
     identifier: Optional[str] = None
 
     stems_per_ha: Optional[float] = None  # RSD record 1
-    species: Optional[Enum] = None  # RSD record 2, 1-8
+    species: Optional[TreeSpecies] = None  # RSD record 2, 1-8
     # RSD record 3, diameter at 1.3 m height
     breast_height_diameter: Optional[float] = None
     height: Optional[float] = None  # RSD record 4, model height in meters
@@ -345,7 +345,7 @@ class ReferenceTree():
             return convert_str_to_type(cls, value, property_name)
         result = cls()
         result.identifier = conv(row[1], "identifier")
-        result.species = TreeSpecies[row[2].split(".")[1]]
+        result.species = TreeSpecies(int(row[2]))
         result.origin = conv(row[3], "origin")
         result.stems_per_ha = conv(row[4], "stems_per_ha")
         result.breast_height_diameter = conv(row[5], "breast_height_diameter")
@@ -366,7 +366,7 @@ class ReferenceTree():
         result.management_category = conv(row[18], "management_category")
         result.tree_category = conv(row[19], "tree_category")
         result.sapling = conv(row[20], "sapling")
-        result.storey = Storey[row[21].split(".")[1]] if row[21] != 'None' else None
+        result.storey = Storey(int(row[21])) if row[21] != 'None' else None
         result.tree_type = conv(row[22], "tree_type")
         result.tuhon_ilmiasu = conv(row[23], "tuhon_ilmiasu")
         return result

--- a/tests/data/model_test.py
+++ b/tests/data/model_test.py
@@ -166,8 +166,8 @@ class TestForestDataModel(unittest.TestCase):
 
     def test_convert_csv_stand_row_with_missing_altitude(self):
         row = "stand;12345;1;2018;436.0;436.0;6834156.23;429291.91;None;EPSG:3067;1019.0;" \
-              "OwnerCategory.METSAHALLITUS;LandUseCategory.FOREST;SoilPeatlandCategory.SPRUCE_MIRE;" \
-              "SiteType.DAMP_SITE;0;3;DrainageCategory.TRANSFORMING_MIRE;True;1984;None;2018;False;None;0;None;None;" \
+              "4;1;2;" \
+              "3;0;3;8;True;1984;None;2018;False;None;0;None;None;" \
               "None;None;10;1;None;12;1;0;False;1.0;1.0;1;10;51"
         row = row.split(';')
         stand = ForestStand.from_csv_row(row)

--- a/tests/resources/file_io_test/forest_centre.csv
+++ b/tests/resources/file_io_test/forest_centre.csv
@@ -1,5 +1,5 @@
-stand;100;None;2020;0.28;0.28;6542843.0;532437.0;None;EPSG:3067;None;OwnerCategory.PRIVATE;LandUseCategory.FOREST;SoilPeatlandCategory.PINE_MIRE;SiteType.DAMP_SITE;0;0;DrainageCategory.TRANSFORMED_MIRE;True;None;None;None;False;None;0;None;None;None;None;-1;1;None;None;None;None;False;1.0;1.0;None;9.5;51.0
-stratum;100-331-stratum;TreeSpecies.SPRUCE;None;None;2.0;2.3;None;10.0;None;None;None;None;1;0.0;0.0;0.0;None;None;None;False;Storey.UNDER;
-stratum;100-332-stratum;TreeSpecies.SPRUCE;None;None;13.1;12.2;None;48.0;5.2;None;None;None;2;0.0;0.0;0.0;None;None;None;False;Storey.DOMINANT;
-stratum;100-333-stratum;TreeSpecies.PINE;None;None;14.5;14.6;None;41.0;4.3;None;None;None;3;0.0;0.0;0.0;None;None;None;False;Storey.DOMINANT;
-stand;101;None;2020;0.45;0.45;6532843.0;536437.0;None;EPSG:3067;None;OwnerCategory.PRIVATE;LandUseCategory.FOREST;SoilPeatlandCategory.PINE_MIRE;SiteType.SUB_DRY_SITE;0;0;DrainageCategory.TRANSFORMED_MIRE;True;None;None;None;False;None;0;None;None;None;None;-1;1;None;None;None;None;False;1.0;1.0;None;None;0.0
+stand;100;None;2020;0.28;0.28;6542843.0;532437.0;None;EPSG:3067;None;1;1;3;3;0;0;8;True;None;None;None;False;None;0;None;None;None;None;-1;1;None;None;None;None;False;1.0;1.0;None;9.5;51.0
+stratum;100-331-stratum;2;None;None;2.0;2.3;None;10.0;None;None;None;None;1;0.0;0.0;0.0;None;None;None;False;2;
+stratum;100-332-stratum;2;None;None;13.1;12.2;None;48.0;5.2;None;None;None;2;0.0;0.0;0.0;None;None;None;False;1;
+stratum;100-333-stratum;1;None;None;14.5;14.6;None;41.0;4.3;None;None;None;3;0.0;0.0;0.0;None;None;None;False;1;
+stand;101;None;2020;0.45;0.45;6532843.0;536437.0;None;EPSG:3067;None;1;1;3;4;0;0;8;True;None;None;None;False;None;0;None;None;None;None;-1;1;None;None;None;None;False;1.0;1.0;None;None;0.0

--- a/tests/resources/file_io_test/testing_output_directory/3/0/unit_state.csv
+++ b/tests/resources/file_io_test/testing_output_directory/3/0/unit_state.csv
@@ -1,1 +1,1 @@
-stand;3;None;2010;0.45;0.45;6775755.4129;506421.7879;None;EPSG:3067;None;OwnerCategory.PRIVATE;LandUseCategory.FOREST;SoilPeatlandCategory.PINE_MIRE;SiteType.DAMP_SITE;0;0;DrainageCategory.TRANSFORMED_MIRE;True;None;None;None;False;None;0;None;None;None;None;-1;1;None;None;None;None;False;1.0;1.0;None;None;None
+stand;3;None;2010;0.45;0.45;6775755.4129;506421.7879;None;EPSG:3067;None;1;1;3;3;0;0;8;True;None;None;None;False;None;0;None;None;None;None;-1;1;None;None;None;None;False;1.0;1.0;None;None;None


### PR DESCRIPTION
Fixes `IntEnum` compatibility issues between `python 3.10` and `3.11.` This is done by implementing `MetsiEnum` which basicly implements `MetsiEnum.__str__ `method as `MetsiEnum.__int__().__str__()`.

Check https://docs.python.org/3/library/enum.html#enum.IntEnum for more.