### PR TITLE
Rsds format

### DIFF
--- a/lukefi/metsi/app/metsi.py
+++ b/lukefi/metsi/app/metsi.py
@@ -23,8 +23,8 @@ def preprocess(config: MetsiConfiguration, control: dict, stands: StandList) -> 
     result = lukefi.metsi.app.preprocessor.preprocess_stands(stands, control)
     if config.preprocessing_output_container is not None:
         print_logline(f"Writing preprocessed data to '{config.target_directory}/preprocessing_result.{config.preprocessing_output_container}'")
-        filepath = determine_file_path(config.target_directory, f"preprocessing_result.{config.preprocessing_output_container}")
-        write_stands_to_file(result, filepath, config.preprocessing_output_container)
+        filepaths = determine_file_path(config.target_directory, config.preprocessing_output_container)
+        write_stands_to_file(result, filepaths, config.preprocessing_output_container)
     return result
 
 

--- a/lukefi/metsi/data/formats/ForestBuilder.py
+++ b/lukefi/metsi/data/formats/ForestBuilder.py
@@ -128,7 +128,7 @@ class VMIBuilder(ForestBuilder):
         result.basal_area = util.parse_type(data_row[indices.basal_area], float)
         result.cutting_year = 0
         result.age_when_10cm_diameter_at_breast_height = 0
-        result.tree_number = 0
+        result.tree_number = util.parse_int(data_row[indices.stratum_number])
         result.stand_origin_relative_position = (0.0, 0.0, 0.0)
         result.lowest_living_branch_height = 0.0
         result.management_category = 1

--- a/lukefi/metsi/data/formats/io_utils.py
+++ b/lukefi/metsi/data/formats/io_utils.py
@@ -96,6 +96,15 @@ def rsd_forest_stand_rows(stand: ForestStand) -> list[str]:
     return result
 
 
+def rsds_forest_stand_rows(stand: ForestStand) -> list[str]:
+    """Generate RSDS data file rows for a single ForestStand"""
+    result = []
+    result.append(" ".join(map(rsd_float, stand.as_rsd_row())))
+    for stratum in stand.tree_strata:
+        result.append(" ".join(map(rsd_float, stratum.as_rsds_row())))
+    return result
+
+
 def csv_value(source: Any) -> str:
     if source is None:
         return "None"
@@ -161,3 +170,8 @@ def outputtable_rows(stands: list[ForestStand], formatter: Callable[[list[Forest
 def stands_to_rsd_content(stands: list[ForestStand]) -> list[str]:
     """Generate RSD file contents for the given list of ForestStand"""
     return outputtable_rows(stands, lambda stand: rsd_forest_stand_rows(stand))
+
+
+def stands_to_rsds_content(stands: list[ForestStand]) -> list[str]:
+    """Generate RSD and RSTS file contents for the given list of ForestStand"""
+    return outputtable_rows(stands, lambda stand: rsds_forest_stand_rows(stand))

--- a/lukefi/metsi/data/model.py
+++ b/lukefi/metsi/data/model.py
@@ -678,7 +678,7 @@ class ForestStand():
             melaed.method_of_last_cutting,
             municipality_id,
             None,
-            0 if melaed.dominant_storey_age is None else melaed.dominant_storey_age,
+            melaed.dominant_storey_age,
         ]
 
 

--- a/lukefi/metsi/data/model.py
+++ b/lukefi/metsi/data/model.py
@@ -381,7 +381,7 @@ class ReferenceTree():
         )
         return [
             melaed.stems_per_ha,
-            melaed.species.value,
+            0 if melaed.species is None else melaed.species.value,
             melaed.breast_height_diameter,
             melaed.height,
             melaed.breast_height_age,

--- a/lukefi/metsi/data/model.py
+++ b/lukefi/metsi/data/model.py
@@ -2,7 +2,7 @@ import dataclasses
 from enum import Enum
 from typing import Optional
 from dataclasses import dataclass
-from lukefi.metsi.data.conversion.internal2mela import mela_stand, mela_tree
+from lukefi.metsi.data.conversion.internal2mela import mela_stand, mela_tree, mela_stratum
 from lukefi.metsi.data.enums.internal import LandUseCategory, OwnerCategory, SiteType, SoilPeatlandCategory, \
     TreeSpecies, DrainageCategory, Storey
 from lukefi.metsi.data.enums.mela import MelaLandUseCategory
@@ -32,7 +32,7 @@ class TreeStratum():
     # identifier of the stratum within the container stand
     identifier: Optional[str] = None
 
-    species: Optional[Enum] = None
+    species: Optional[TreeSpecies] = None
     origin: Optional[int] = None
     stems_per_ha: Optional[float] = None  # stem count within a hectare
     mean_diameter: Optional[float] = None  # in decimeters
@@ -53,6 +53,7 @@ class TreeStratum():
     sapling_stems_per_ha: Optional[float] = None
     sapling_stratum: bool = False  # this reference tree represents saplings
     storey: Optional[Storey] = None
+    number_of_generated_trees: Optional[int] = None
 
     def __hash__(self):
         return id(self)
@@ -215,6 +216,23 @@ class TreeStratum():
         result.sapling_stratum = conv(row[20], "sapling_stratum")
         result.storey = Storey(int(row[21])) if row[21] != "None" else None
         return result
+    
+    def as_rsds_row(self):
+        melaed = mela_stratum(self)
+        return [
+            melaed.tree_number,
+            0 if melaed.species is None else melaed.species.value,
+            melaed.origin,
+            melaed.stems_per_ha,
+            melaed.mean_diameter,
+            melaed.mean_height,
+            melaed.breast_height_age,
+            melaed.biological_age,
+            melaed.basal_area,
+            melaed.sapling_stems_per_ha,
+            0 if melaed.storey is None else melaed.storey.value,
+            melaed.number_of_generated_trees
+        ]
 
 @dataclass
 class ReferenceTree():

--- a/lukefi/metsi/forestry/preprocessing/tree_generation.py
+++ b/lukefi/metsi/forestry/preprocessing/tree_generation.py
@@ -16,11 +16,12 @@ class TreeStrategy(Enum):
 
 def finalize_trees(reference_trees: list[ReferenceTree], stratum: TreeStratum) -> list[ReferenceTree]:
     """ For all given trees inflates the common variables from stratum. """
-    n_trees = len(reference_trees)
+    stratum.number_of_generated_trees = len(reference_trees)
     for i, reference_tree in enumerate(reference_trees):
         reference_tree.stand = stratum.stand
         reference_tree.species = stratum.species
-        reference_tree.breast_height_age = 0.0 if n_trees == 1 else stratum.get_breast_height_age()
+        reference_tree.breast_height_age = 0.0 \
+            if stratum.number_of_generated_trees == 1 else stratum.get_breast_height_age()
         reference_tree.biological_age = stratum.biological_age
         if reference_tree.breast_height_age == 0.0 and reference_tree.breast_height_diameter > 0.0:
             reference_tree.breast_height_age = 1.0

--- a/tests/app/file_io_test.py
+++ b/tests/app/file_io_test.py
@@ -19,6 +19,18 @@ class Test:
 
 
 class TestFileReading(unittest.TestCase):
+    def test_determine_file_path(self):
+        assertions = [
+            (('testdir', 'rsd'), (
+                Path('testdir', 'preprocessing_result.rsd'),
+                Path('testdir', 'preprocessing_result.rsds'))
+            ),
+            (('testdir', 'csv'), ( Path('testdir', 'preprocessing_result.csv'), )), # single tuple
+        ]
+        for a in assertions:
+            result = lukefi.metsi.app.file_io.determine_file_path(*a[0])
+            self.assertEqual(a[1], result) 
+
     def test_file_contents(self):
         input_file_path = os.path.join(os.getcwd(), "tests", "resources", "file_io_test", "test_dummy")
         result = lukefi.metsi.app.file_io.file_contents(input_file_path)
@@ -110,6 +122,48 @@ class TestFileReading(unittest.TestCase):
         self.assertTrue(exists)
         self.assertTrue(size > 0)
         shutil.rmtree('outdir')
+
+
+    def test_rsds(self):
+        data = [
+            ForestStand(
+                identifier="123-234",
+                geo_location=(600000.0, 300000.0, 30.0, "EPSG:3067"),
+                land_use_category=LandUseCategory.FOREST,
+                owner_category=OwnerCategory.PRIVATE,
+                soil_peatland_category=SoilPeatlandCategory.MINERAL_SOIL,
+                site_type_category=SiteType.RICH_SITE,
+                drainage_category=DrainageCategory.DITCHED_MINERAL_SOIL,
+                fra_category="1",
+                auxiliary_stand=False,
+                tree_strata=[
+                    TreeStratum(
+                        identifier="123-234-1",
+                        tree_number=1,
+                        species=TreeSpecies.PINE,
+                        stems_per_ha=200.0,
+                        mean_diameter=20.0,
+                        mean_height=15.0,
+                        breast_height_age=52,
+                        biological_age=55,
+                        basal_area=210.0,
+                        sapling_stems_per_ha=100.0,
+                        storey=Storey.DOMINANT
+                    )
+                ]
+            )
+        ]
+        lukefi.metsi.app.file_io.prepare_target_directory("outdir")
+        target = Path("outdir", "output.rsds")
+        lukefi.metsi.app.file_io.rsds_writer(target, data)
+
+        # There is no rsd input so check sanity just by file existence and non-emptiness
+        exists = os.path.exists(target)
+        size = os.path.getsize(target)
+        self.assertTrue(exists)
+        self.assertTrue(size > 0)
+        shutil.rmtree('outdir')
+
 
     def test_read_stands_from_pickle_file(self):
         config = MetsiConfiguration(

--- a/tests/data/io_test.py
+++ b/tests/data/io_test.py
@@ -22,10 +22,20 @@ class IoUtilsTest(ConverterTestSuite):
         result = rsd_forest_stand_rows(vmi13_stands[1])
         self.assertEqual(4, len(result))
 
+    def test_rsds_forest_stand_rows(self):
+        vmi13_stands = vmi13_builder.build()
+        result = rsds_forest_stand_rows(vmi13_stands[1])
+        self.assertEqual(3, len(result))
+
     def test_rsd_rows(self):
         vmi13_stands = vmi13_builder.build()
         result = stands_to_rsd_content(vmi13_stands)
         self.assertEqual(9, len(result))
+
+    def test_rsds_rows(self):
+        vmi13_stands = vmi13_builder.build()
+        result = stands_to_rsds_content(vmi13_stands)
+        self.assertEqual(6, len(result))
 
     def test_stands_to_csv(self):
         delimiter = ";"

--- a/tests/data/vmi_builder_test.py
+++ b/tests/data/vmi_builder_test.py
@@ -228,6 +228,7 @@ class TestForestBuilder(unittest.TestCase):
         # basal area is '17' -> 17.0
         self.assertEqual(17.0, stratum.basal_area)
         self.assertEqual(Storey.DOMINANT, stratum.storey)
+        self.assertEqual(1, stratum.tree_number)
 
     def test_vmi13_init(self):
         vmi13_builder = self.vmi13_builder()
@@ -415,6 +416,7 @@ class TestForestBuilder(unittest.TestCase):
         # basal area is '17' -> 17.0
         self.assertEqual(17.0, stratum.basal_area)
         self.assertEqual(Storey.DOMINANT, stratum.storey)
+        self.assertEqual(1, stratum.tree_number)
 
 
     def test_remove_strata(self):

--- a/tests/forestry/preprocessing_tests/tree_generation_test.py
+++ b/tests/forestry/preprocessing_tests/tree_generation_test.py
@@ -42,13 +42,14 @@ class TestTreeGeneration(unittest.TestCase):
         self.assertEqual(1.9357767362985978, result[0].stems_per_ha)
 
     def test_finalize_trees(self):
+        n_trees = 4
         stratum = TreeStratum()
         stratum.species = 1
         stratum.stand = '0-012-001-01-1'
         stratum.breast_height_age = 25.0
         stratum.biological_age = 32.0
         reference_trees = []
-        for i in range(4):
+        for i in range(n_trees):
             reference_trees.append(ReferenceTree())
         result = tree_generation.finalize_trees(reference_trees, stratum)
         self.assertEqual('0-012-001-01-1', result[0].stand)
@@ -61,6 +62,9 @@ class TestTreeGeneration(unittest.TestCase):
         self.assertEqual(32.0, result[1].biological_age)
         self.assertEqual(1, result[0].tree_number)
         self.assertEqual(2, result[1].tree_number)
+        # also test the inflating of TreeStratum.number_of_generated_trees
+        self.assertEqual(stratum.number_of_generated_trees, n_trees)
+
 
     def test_solve_tree_generation_strategy(self):
         # Test data generation


### PR DESCRIPTION
`RSDS` format is an <ins>experimental format</ins> which is implemented in respect of the `RSD` format.
`RSD` format includes only reference tree information of stands.
`RSDS` includes the <ins>starta information of the genereted reference trees</ins> to preprocessing output.
 - I.E. <mark>now when `RSD` is generated with Metsi one also gets the `RSDS` information as output</mark>.

The abbreviation `RSDS` comes from the original `RSD` format plus an additional S meaning Stratum (fin: Osite).