### PR TITLE
ci: updated GHA runner

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -23,7 +23,7 @@ jobs:
         python-version: ["3.10.0", "3.11.9", "3.12.5"]
         r-version: ["4.1.3", "4.3.3"]
         
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Ubuntu 20.04 is depricated. Updated to use always the latest VM image.

Additional info about the depricated VM.
- https://github.com/actions/runner-images/issues/11101