### PR TITLE
Fix shared lib load

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,34 @@
+name: Build and Release DLL
+
+on:
+  push:
+    tags:
+      - '*'  # Eg. 1.0.0 launches the workflow runner
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Make
+        uses: msys2/setup-msys2@v2
+        with:
+          install: make mingw-w64-x86_64-gcc
+          msystem: MINGW64
+
+      - name: Build .dll in c_extensions using Makefile
+        shell: msys2 {0}
+        run: |
+          cd lukefi/metsi/forestry/c
+          make
+
+      - name: Upload release asset
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            lukefi/metsi/forestry/c/lib/ykjtm35.dll
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/lukefi/metsi/forestry/preprocessing/coordinate_conversion.py
+++ b/lukefi/metsi/forestry/preprocessing/coordinate_conversion.py
@@ -5,13 +5,20 @@ from enum import Enum
 from lukefi.metsi.data.model import ForestStand
 
 
+def load_library(path):
+    """ Load a shared library from the given path, handling compatibility for Python < 3.12. """ 
+    if sys.version_info >= (3, 12):
+        return cts.CDLL(path)
+    else:
+        return cts.CDLL(str(path))
+
 
 # Defining and initialize the external library 
 lib_name = 'ykjtm35.dll' if sys.platform == "win32" else 'ykjtm35.so' 
 DLL_PATH = Path('lukefi', 'metsi', 'forestry', 'c', 'lib', lib_name)
 
 try:
-    DLL = cts.CDLL(DLL_PATH)
+    DLL = load_library(DLL_PATH)
 except OSError as e:
     print(f"Failed to load {lib_name}: {e}")
 


### PR DESCRIPTION
Fixes the problem with python < 3.12:
- `ctypes.CDLL` `name` parameter does not support `patlib.Path` objects

Also added a GHA workflow for builing a .dll for coordinate_conversion with YKJ and storing it to Metsi [releases](https://github.com/lukefi/metsi/releases).
- https://github.com/lukefi/metsi/pull/70