### PR TITLE
feature: convert to vectorized  #MELA2-37, #MELA2-43

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2.1.0] - 2025-06-23
+
+### Added
+
+- Added 'vectorize' pre-processing operation
+- Added 'npy' and 'npz' export_prepro options
+
 ## [2.0.4] - 2025-06-23
 
 ### Changed
@@ -25,7 +32,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Implemented partial file simulation #MELA2-45
 - Added Robot test SMK_02_partial 
 
-
 ## [2.0.1] - 2025-06-16
 
 ### Changed
@@ -38,8 +44,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 - Control structure now contains direct function references instead of lookup strings for generators and operations
-
-
 
 ## [1.2.4] - 2025-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [2.1.0] - 2025-06-23
+## [2.1.0] - 2025-06-24
 
 ### Added
 

--- a/examples/control_vector.py
+++ b/examples/control_vector.py
@@ -1,0 +1,39 @@
+from lukefi.metsi.domain.pre_ops import (generate_reference_trees, preproc_filter, vectorize)
+
+control_structure = {
+    "app_configuration": {
+        "state_format": "vmi13",  # options: fdm, vmi12, vmi13, xml, gpkg
+        "strata_origin": 2,
+        "run_modes": ["preprocess", "export_prepro"]
+    },
+    "preprocessing_operations": [
+        generate_reference_trees,  # reference trees from strata, replaces existing reference trees
+        preproc_filter,
+        vectorize
+    ],
+    "preprocessing_params": {
+        generate_reference_trees: [
+            {
+                "n_trees": 10,
+                "method": "weibull",
+                "debug": False
+            }
+        ],
+        preproc_filter: [
+            {
+                "remove trees": "sapling or stems_per_ha == 0",
+                "remove stands": "(site_type_category == 0) or (site_type_category == None)",  # not reference_trees
+            }
+        ]
+    },
+    'export_prepro': {
+        # "csv": {},  # default csv export
+        # "rst": {},
+        # "json": {}
+        "pickle": {},
+        "npy": {},
+        "npz": {},
+    }
+}
+
+__all__ = ['control_structure']

--- a/lukefi/metsi/app/app_io.py
+++ b/lukefi/metsi/app/app_io.py
@@ -19,7 +19,7 @@ class MetsiConfiguration(SimpleNamespace):
 
     # Default configuration values
     control_file = "control.py"
-    input_path = None
+    input_path = ""
     target_directory = None
     run_modes = [RunMode.PREPROCESS, RunMode.EXPORT_PREPRO, RunMode.SIMULATE, RunMode.POSTPROCESS, RunMode.EXPORT]
     state_format = StateFormat.FDM

--- a/lukefi/metsi/app/file_io.py
+++ b/lukefi/metsi/app/file_io.py
@@ -5,6 +5,7 @@ import importlib.util
 from collections.abc import Iterator, Callable
 from pathlib import Path
 from typing import Any, Optional
+import numpy as np
 import jsonpickle
 from lukefi.metsi.data.formats.ForestBuilder import VMI13Builder, VMI12Builder, XMLBuilder, GeoPackageBuilder
 from lukefi.metsi.data.formats.io_utils import stands_to_csv_content, csv_content_to_stands, \
@@ -54,6 +55,10 @@ def stand_writer(container_format: str) -> StandWriter:
         return rst_writer
     if container_format == "rsts":
         return rsts_writer
+    if container_format == "npy":
+        return npy_writer
+    if container_format == "npz":
+        return npz_writer
     raise Exception(f"Unsupported container format '{container_format}'")
 
 
@@ -310,6 +315,16 @@ def rst_writer(filepath: Path, container: ExportableContainer[ForestStand]):
 # - voidaanko tälle tehdä sama kuin par_writerille?
 def rsts_writer(filepath: Path, container: ExportableContainer[ForestStand]):
     row_writer(filepath, stands_to_rsts_content(container))
+
+
+def npy_writer(filepath: Path, container: ExportableContainer[ForestStand]):
+    stands = container.export_objects
+    np.save(filepath, allow_pickle=True, arr=np.array(stands, dtype=object))
+
+
+def npz_writer(filepath: Path, container: ExportableContainer[ForestStand]):
+    stands = container.export_objects
+    np.savez(filepath, allow_pickle=True, *[np.array(stand) for stand in stands])
 
 
 def par_writer(filepath: Path, var_names: list[str]):

--- a/lukefi/metsi/app/file_io.py
+++ b/lukefi/metsi/app/file_io.py
@@ -281,13 +281,13 @@ def read_control_module(control_path: str, control: str = "control_structure") -
 
 
 ##### FileWriters start #####
-def pickle_writer(filepath: Path, container: ObjectLike | ExportableContainer[ForestStand]):
+def pickle_writer(filepath: Path, container: ObjectLike | ExportableContainer):
     outputtable = container.export_objects if isinstance(container, ExportableContainer) else container
     with open(filepath, 'wb') as f:
         pickle.dump(outputtable, f, protocol=5)
 
 
-def json_writer(filepath: Path, container: ObjectLike | ExportableContainer[ForestStand]):
+def json_writer(filepath: Path, container: ObjectLike | ExportableContainer):
     outputtable = container.export_objects if isinstance(container, ExportableContainer) else container
     jsonpickle.set_encoder_options("json", indent=2)
     with open(filepath, 'w', newline='\n', encoding="utf-8") as f:
@@ -317,12 +317,12 @@ def rsts_writer(filepath: Path, container: ExportableContainer[ForestStand]):
     row_writer(filepath, stands_to_rsts_content(container))
 
 
-def npy_writer(filepath: Path, container: ExportableContainer[ForestStand]):
+def npy_writer(filepath: Path, container: ExportableContainer):
     stands = container.export_objects
     np.save(filepath, allow_pickle=True, arr=np.array(stands, dtype=object))
 
 
-def npz_writer(filepath: Path, container: ExportableContainer[ForestStand]):
+def npz_writer(filepath: Path, container: ExportableContainer):
     stands = container.export_objects
     np.savez(filepath, allow_pickle=True, *[np.array(stand) for stand in stands])
 
@@ -356,3 +356,15 @@ def json_reader(file_path: str | Path) -> StandList:
 def pickle_reader(file_path: str | Path) -> StandList:
     with open(file_path, 'rb') as f:
         return pickle.load(f)
+
+def npy_file_reader(file_path: str | Path) -> np.ndarray:
+    with open(file_path, 'rb') as f:
+        return np.load(f, allow_pickle=True)
+
+def npz_file_reader(file_path: str | Path):
+    with np.load(file_path, allow_pickle=True) as data:
+        retval = []
+        for v in data.values():
+            retval.append(v)
+    return retval
+    

--- a/lukefi/metsi/app/file_io.py
+++ b/lukefi/metsi/app/file_io.py
@@ -1,11 +1,11 @@
 import csv
 import os
 import pickle
-import jsonpickle
-import importlib
+import importlib.util
+from collections.abc import Iterator, Callable
 from pathlib import Path
 from typing import Any, Optional
-from collections.abc import Iterator, Callable
+import jsonpickle
 from lukefi.metsi.data.formats.ForestBuilder import VMI13Builder, VMI12Builder, XMLBuilder, GeoPackageBuilder
 from lukefi.metsi.data.formats.io_utils import stands_to_csv_content, csv_content_to_stands, \
     stands_to_rst_content, stands_to_rsts_content, mela_par_file_content
@@ -16,9 +16,9 @@ from lukefi.metsi.domain.forestry_types import StandList, ForestStand
 from lukefi.metsi.sim.core_types import CollectedData
 from lukefi.metsi.data.formats.declarative_conversion import Conversion
 
-StandReader = Callable[[str], StandList]
+StandReader = Callable[[str | Path], StandList]
 StandWriter = Callable[[Path, ExportableContainer[ForestStand]], None]
-ObjectLike = StandList or SimResults or CollectedData
+ObjectLike = StandList | SimResults | CollectedData
 ObjectWriter = Callable[[Path, ObjectLike], None]
 
 # io_utils?
@@ -34,27 +34,27 @@ def prepare_target_directory(path_descriptor: str) -> Path:
     if os.path.exists(path_descriptor):
         if os.path.isdir(path_descriptor) and os.access(path_descriptor, os.W_OK):
             return Path(path_descriptor)
-        else:
-            raise Exception("Output directory {} not available. Ensure it is a writable and empty, or a non-existing directory.".format(path_descriptor))
-    else:
-        os.makedirs(path_descriptor)
-        return Path(path_descriptor)
+        raise Exception(
+            f"Output directory {path_descriptor} not available. Ensure it is a writable and empty, "
+            "or a non-existing directory.")
+
+    os.makedirs(path_descriptor)
+    return Path(path_descriptor)
 
 # solve FileWriter - interface
 def stand_writer(container_format: str) -> StandWriter:
     """Return a serialization file writer function for a ForestDataPackage"""
     if container_format == "pickle":
         return pickle_writer
-    elif container_format == "json":
+    if container_format == "json":
         return json_writer
-    elif container_format == "csv":
+    if container_format == "csv":
         return csv_writer
-    elif container_format == "rst":
+    if container_format == "rst":
         return rst_writer
-    elif container_format == "rsts":
+    if container_format == "rsts":
         return rsts_writer
-    else:
-        raise Exception(f"Unsupported container format '{container_format}'")
+    raise Exception(f"Unsupported container format '{container_format}'")
 
 
 # entry of FileWriter
@@ -68,18 +68,17 @@ def object_writer(container_format: str) -> ObjectWriter:
     """Return a serialization file writer function for arbitrary data"""
     if container_format == "pickle":
         return pickle_writer
-    elif container_format == "json":
+    if container_format == "json":
         return json_writer
-    else:
-        raise Exception(f"Unsupported container format '{container_format}'")
+    raise Exception(f"Unsupported container format '{container_format}'")
 
 # io_utils
-def determine_file_path(dir: Path, filename: str) -> Path:
-    return Path(dir, filename)
+def determine_file_path(dir_: str | Path, filename: str) -> Path:
+    return Path(dir_, filename)
 
 # io_utils
-def file_contents(file_path: str) -> str:
-    with open(file_path, 'r') as f:
+def file_contents(file_path: str | Path) -> str:
+    with open(file_path, 'r', encoding="utf-8") as f:
         return f.read()
 
 # solve FdmReader
@@ -87,33 +86,32 @@ def fdm_reader(container_format: str) -> StandReader:
     """Resolve a reader function for FDM data containers"""
     if container_format == "pickle":
         return pickle_reader
-    elif container_format == "json":
+    if container_format == "json":
         return json_reader
-    elif container_format == "csv":
+    if container_format == "csv":
         return lambda path: csv_content_to_stands(csv_file_reader(path))
-    else:
-        raise Exception(f"Unsupported container format '{container_format}'")
+    raise Exception(f"Unsupported container format '{container_format}'")
 
 # solve ObjectReader
 def object_reader(container_format: str) -> Any:
     if container_format == "pickle":
         return pickle_reader
-    elif container_format == "json":
+    if container_format == "json":
         return json_reader
-    else:
-        raise Exception(f"Unsupported container format '{container_format}'")
+    raise Exception(f"Unsupported container format '{container_format}'")
 
 # SourceDataReaders
 def external_reader(state_format: str, conversions, **builder_flags) -> StandReader:
     """Resolve and prepare a reader function for non-FDM data formats"""
     if state_format == "vmi13":
         return lambda path: VMI13Builder(builder_flags, conversions.get('vmi13', {}), vmi_file_reader(path)).build()
-    elif state_format == "vmi12":
+    if state_format == "vmi12":
         return lambda path: VMI12Builder(builder_flags, conversions.get('vmi12', {}), vmi_file_reader(path)).build()
-    elif state_format == "xml":
+    if state_format == "xml":
         return lambda path: XMLBuilder(builder_flags, conversions.get('xml', {}), xml_file_reader(path)).build()
-    elif state_format == "gpkg":
-        return lambda path: GeoPackageBuilder(builder_flags, conversions.get('gpkg', {}), path).build()    
+    if state_format == "gpkg":
+        return lambda path: GeoPackageBuilder(builder_flags, conversions.get('gpkg', {}), str(path)).build()
+    raise Exception(f"Unsupported state format '{state_format}'")
 
 # source data main entry function
 def read_stands_from_file(app_config: MetsiConfiguration, conversions: dict[str, Conversion]) -> StandList:
@@ -125,16 +123,15 @@ def read_stands_from_file(app_config: MetsiConfiguration, conversions: dict[str,
     :return: list of ForestStands as computational units for simulation
     """
     if app_config.state_format == "fdm":
-        return fdm_reader(app_config.state_input_container)(app_config.input_path)
-    elif app_config.state_format in ("vmi13", "vmi12", "xml", "gpkg"):
+        return fdm_reader(app_config.state_input_container.value)(app_config.input_path)
+    if app_config.state_format in ("vmi13", "vmi12", "xml", "gpkg"):
         return external_reader(
-            app_config.state_format,
+            app_config.state_format.value,
             conversions,
             strata=app_config.strata,
             measured_trees=app_config.measured_trees,
             strata_origin=app_config.strata_origin)(app_config.input_path)
-    else:
-        raise Exception(f"Unsupported state format '{app_config.state_format}'")
+    raise Exception(f"Unsupported state format '{app_config.state_format}'")
 
 # io_util?
 def scan_dir_for_file(dirpath: Path, basename: str, suffixes: list[str]) -> Optional[tuple[Path, str]]:
@@ -157,8 +154,7 @@ def parse_file_or_default(file: Path, reader: Callable[[Path], Any], default=Non
     """Deserialize given file with given reader function or return default"""
     if os.path.exists(file):
         return reader(file)
-    else:
-        return default
+    return default
 
 # SimResultReader utility - scans schedules from files
 def read_schedule_payload_from_directory(schedule_path: Path) -> ForestOpPayload:
@@ -169,12 +165,29 @@ def read_schedule_payload_from_directory(schedule_path: Path) -> ForestOpPayload
     :param schedule_path: Path for a schedule directory
     :return: OperationPayload with computational_unit and collected_data if found
     """
-    unit_state_file, input_container = scan_dir_for_file(schedule_path, "unit_state", ["csv", "json", "pickle"])
-    derived_data_file, derived_data_container = scan_dir_for_file(schedule_path, "derived_data", ["json", "pickle"])
-    stands = [] if unit_state_file is None else parse_file_or_default(unit_state_file, fdm_reader(input_container), [])
-    derived_data = None if derived_data_file is None else parse_file_or_default(derived_data_file, object_reader(derived_data_container))
+    scan_result = scan_dir_for_file(schedule_path, "unit_state", ["csv", "json", "pickle"])
+    # unit_state_file, input_container = scan_dir_for_file(schedule_path, "unit_state", ["csv", "json", "pickle"])
+    if scan_result is not None:
+        unit_state_file, input_container = scan_result
+    else:
+        unit_state_file = None
+        input_container = None
+
+    scan_result = scan_dir_for_file(schedule_path, "derived_data", ["json", "pickle"])
+    # derived_data_file, derived_data_container = scan_dir_for_file(schedule_path, "derived_data", ["json", "pickle"])
+    if scan_result is not None:
+        derived_data_file, derived_data_container = scan_result
+    else:
+        derived_data_file = None
+        derived_data_container = None
+
+    stands = [] if unit_state_file is None or input_container is None else parse_file_or_default(
+        unit_state_file, fdm_reader(input_container), [])
+    derived_data = None if derived_data_file is None or derived_data_container is None else parse_file_or_default(
+        derived_data_file, object_reader(derived_data_container))
+
     return ForestOpPayload(
-        computational_unit=None if stands == [] else stands[0],
+        computational_unit=None if stands == [] or stands is None else stands[0],
         collected_data=derived_data,
         operation_history=[]
     )
@@ -201,16 +214,20 @@ def read_full_simulation_result_dirtree(source_path: Path) -> SimResults:
         return map(lambda schedule: Path(stand_path, schedule), schedules)
     result = {}
     stand_identifiers = get_subdirectory_names(source_path)
-    stands_to_schedules = map(lambda stand_id: (stand_id, schedulepaths_for_stand(Path(source_path, stand_id))), stand_identifiers)
+    stands_to_schedules = map(lambda stand_id: (
+        stand_id, schedulepaths_for_stand(Path(source_path, stand_id))), stand_identifiers)
     for stand_id, schedulepaths in stands_to_schedules:
-        payloads = list(map(lambda schedulepath: read_schedule_payload_from_directory(schedulepath), schedulepaths))
+        payloads = list(map(read_schedule_payload_from_directory, schedulepaths))
         result[stand_id] = payloads
     return result
 
 # CollectedResults writer, done when SimResults are written.
 # - can be seen as indivudual entry for writing CollectedResults
 def write_derived_data_to_file(result: CollectedData, filepath: Path, derived_data_output_container: str):
-    """Resolve a writer function for AggregatedResults matching the given derived_data_output_container. Invokes write."""
+    """
+    Resolve a writer function for AggregatedResults matching the given derived_data_output_container.
+    Invokes write.
+    """
     writer = object_writer(derived_data_output_container)
     writer(filepath, result)
 
@@ -237,7 +254,8 @@ def write_full_simulation_result_dirtree(result: SimResults, app_arguments: Mets
             if app_arguments.derived_data_output_container is not None:
                 schedule_dir = prepare_target_directory(f"{app_arguments.target_directory}/{stand_id}/{i}")
                 filepath = determine_file_path(schedule_dir, app_arguments.derived_data_output_container)
-                write_derived_data_to_file(schedule.collected_data, filepath, app_arguments.derived_data_output_container)
+                write_derived_data_to_file(schedule.collected_data, filepath,
+                                           app_arguments.derived_data_output_container)
 
 
 def read_control_module(control_path: str, control: str = "control_structure") -> dict[str, Any]:
@@ -259,20 +277,20 @@ def read_control_module(control_path: str, control: str = "control_structure") -
 
 ##### FileWriters start #####
 def pickle_writer(filepath: Path, container: ObjectLike | ExportableContainer[ForestStand]):
-    outputtable = container.result_objects if type(container) is ExportableContainer else container
+    outputtable = container.export_objects if isinstance(container, ExportableContainer) else container
     with open(filepath, 'wb') as f:
         pickle.dump(outputtable, f, protocol=5)
 
 
 def json_writer(filepath: Path, container: ObjectLike | ExportableContainer[ForestStand]):
-    outputtable = container.export_objects if type(container) is ExportableContainer else container
+    outputtable = container.export_objects if isinstance(container, ExportableContainer) else container
     jsonpickle.set_encoder_options("json", indent=2)
-    with open(filepath, 'w', newline='\n') as f:
-        f.write(jsonpickle.encode(outputtable))
+    with open(filepath, 'w', newline='\n', encoding="utf-8") as f:
+        f.write(str(jsonpickle.encode(outputtable)))
 
 # generic writer
 def row_writer(filepath: Path, rows: list[str]):
-    with open(filepath, 'a', newline='\n') as file:
+    with open(filepath, 'a', newline='\n', encoding="utf-8") as file:
         for row in rows:
             file.write(row)
             file.write('\n')
@@ -301,26 +319,25 @@ def par_writer(filepath: Path, var_names: list[str]):
     row_writer(to_par_filepath(filepath), mela_par_file_content(var_names))
 
 ##### SourceFileReaders start #####
-def vmi_file_reader(file: Path) -> list[str]:
+def vmi_file_reader(file: str | Path) -> list[str]:
     with open(file, 'r', encoding='utf-8') as input_file:
         return input_file.readlines()
 
 
-def xml_file_reader(file: Path) -> str:
+def xml_file_reader(file: str | Path) -> str:
     with open(file, 'r', encoding='utf-8') as input_file:
         return input_file.read()
 
 
-def csv_file_reader(file: Path) -> list[list[str]]:
+def csv_file_reader(file: str | Path) -> list[list[str]]:
     with open(file, 'r', encoding='utf-8') as input_file:
         return list(csv.reader(input_file, delimiter=';'))
 
 ## ObjectFileReaders start ##
-def json_reader(file_path: str) -> ObjectLike:
-    res = jsonpickle.decode(file_contents(file_path))
-    return res
+def json_reader(file_path: str | Path) -> StandList:
+    return jsonpickle.decode(file_contents(file_path)) # type: ignore
 
 
-def pickle_reader(file_path: str) -> ObjectLike:
+def pickle_reader(file_path: str | Path) -> StandList:
     with open(file_path, 'rb') as f:
         return pickle.load(f)

--- a/lukefi/metsi/data/vectorize.py
+++ b/lukefi/metsi/data/vectorize.py
@@ -153,9 +153,3 @@ def vectorize(stands: list[ForestStand], **operation_params) -> list[ForestStand
 
 
 __all__ = ["vectorize"]
-
-if __name__ == "__main__":
-    stands_ = [ForestStand(reference_trees=[ReferenceTree(species=TreeSpecies(1)),
-                                           ReferenceTree(species=TreeSpecies(2))])]
-    vectorize(stands_)
-    pprint(stands_)

--- a/lukefi/metsi/data/vectorize.py
+++ b/lukefi/metsi/data/vectorize.py
@@ -128,15 +128,14 @@ CONTAINERS = {
 }
 
 
-def vectorize(stands_: StandList, **operation_params) -> StandList:
-
+def vectorize(stands: list[ForestStand], **operation_params) -> list[ForestStand]:
     target = operation_params.get('target', None)
     if target is None:
         target = ['reference_trees', 'tree_strata']
     else:
         target = [target]
 
-    for stand in stands_:
+    for stand in stands:
         for t in target:
             attr_dict: dict[str, Any] = {}
 
@@ -151,13 +150,13 @@ def vectorize(stands_: StandList, **operation_params) -> StandList:
                 raise Exception(f"Unknown target type '{t}'")
             setattr(stand, t, container_obj().vectorize(attr_dict))
 
-    return stands_
+    return stands
 
 
 __all__ = ["vectorize"]
 
 if __name__ == "__main__":
-    stands = [ForestStand(reference_trees=[ReferenceTree(species=TreeSpecies(1)),
+    stands_ = [ForestStand(reference_trees=[ReferenceTree(species=TreeSpecies(1)),
                                            ReferenceTree(species=TreeSpecies(2))])]
-    vectorize(stands)
-    pprint(stands)
+    vectorize(stands_)
+    pprint(stands_)

--- a/lukefi/metsi/data/vectorize.py
+++ b/lukefi/metsi/data/vectorize.py
@@ -1,0 +1,157 @@
+import numpy as np
+import numpy.typing as npt
+from typing import Optional, Any
+from lukefi.metsi.data.model import ForestStand, ReferenceTree, TreeStratum
+from lukefi.metsi.domain.forestry_types import StandList
+from dataclasses import dataclass
+from lukefi.metsi.data.formats.util import get_or_default 
+
+
+
+DTYPE_TREE = np.dtype([
+        ("identifier", "U20"),
+        ("tree_number", np.int32),
+        ("species", np.int32),
+        ("breast_height_diameter", np.float64),
+        ("height", np.float64),
+        ("measured_height", np.float64),
+        ("breast_height_age", np.float64),
+        ("biological_age", np.float64),
+        ("stems_per_ha", np.float64),
+        ("origin", np.int32),
+        ("management_category", np.int32),
+        ("saw_log_volume_reduction_factor", np.float64),
+        ("pruning_year", np.int16),
+        ("age_when_10cm_diameter_at_breast_height", np.int16),
+        ("stand_origin_relative_position", np.float64, (3,)),
+        ("lowest_living_branch_height", np.float64),
+        ("tree_category", np.str_),
+        ("storey", np.int32),
+        ("sapling", np.bool_),
+        ("tree_type", "U20"),
+        ("tuhon_ilmiasu", "U20"),
+        ("latvuskerros", np.float64) # NOTE: for benchmarking purposes
+    ])
+    
+DTYPE_STRATA = np.dtype([
+    ("identifier", "U20"),
+    ("species", np.int32),
+    ("mean_diameter", np.float64),
+    ("mean_height", np.float64),
+    ("breast_height_age", np.float64),
+    ("biological_age", np.int32),
+    ("stems_per_ha", np.float64),
+    ("basal_area", np.float64),
+    ("origin", np.int32),
+    ("management_category", np.int32),
+    ("saw_log_volume_reduction_factor", np.float64),
+    ("cutting_year", np.int32),
+    ("age_when_10cm_diameter_at_breast_height", np.int16),
+    ("tree_number", np.int32),
+    ("stand_origin_relative_position", np.float64, (3,)),
+    ("lowest_living_branch_height", np.float64),
+    ("storey", np.int32),
+    ("sapling_stems_per_ha", np.float64),
+    ("sapling_stratum", np.bool_),
+    ("number_of_generated_trees", np.int32)
+])
+
+
+@dataclass
+class VectorData():
+    def __init__(self, dtype):
+        self.dtype = dtype
+
+    def vectorize(self, attr_dict):
+        for k, v in attr_dict.items():
+            setattr(self, k, np.array(self.defaultify(v, self.dtype[k]), self.dtype[k]))
+            if not self.is_contiguous(k):
+                raise("Vectorized data is not contiguous")
+        self.set_size(attr_dict)
+        return self
+
+    def is_contiguous(self, name):
+        arr = getattr(self, name)
+        return True if arr.flags['CONTIGUOUS'] and arr.flags['C_CONTIGUOUS'] else False 
+
+    def set_size(self, attr_dict):
+        size = len(attr_dict.get('identifier', []))
+        setattr(self, 'size', size)
+
+    def defaultify(self, values: list, dtype: npt.DTypeLike) -> list:
+        return [ self.to_default(v, dtype) for v in values]
+
+    def to_default(self, value: Optional[Any], field_type: npt.DTypeLike) -> Any:
+        """ Replace None with appropriate defaults based on field type. """
+        int_default = -1
+        str_default = ""
+        float_default = np.nan
+        bool_default = False
+        tuple_default = (np.nan, np.nan, np.nan)
+        object_default = None
+        
+        if value is None:
+            if np.issubdtype(field_type, np.integer):
+                return int_default
+            elif np.issubdtype(field_type, np.floating):
+                return float_default
+            elif np.issubdtype(field_type, np.str_):
+                return str_default
+            elif np.issubdtype(field_type, np.bool_):
+                return bool_default
+            elif np.issubdtype(field_type, np.void):
+                return tuple_default
+            else:
+                return object_default
+        return value
+
+
+@dataclass
+class ReferenceTrees(VectorData):
+
+    def __init__(self):
+        super().__init__(DTYPE_TREE)
+
+
+@dataclass
+class Strata(VectorData):
+    
+    def __init__(self):
+        super().__init__(DTYPE_STRATA)
+
+
+CONTAINERS = {
+    "reference_trees": ReferenceTrees,
+    "tree_strata": Strata
+}
+
+def vectorize(stands: StandList, **operation_params) -> StandList:
+   
+    target = operation_params.get('target', None)
+    if target == None:
+        target = ['reference_trees', 'tree_strata']
+    else:
+        target = [target]
+
+    for stand in stands:
+        for t in target:
+            attr_dict = {}
+
+            for data in getattr(stand, t, []):
+                delattr(data, "stand")
+                for k, v in data.__dict__.items():
+                    attr_dict.setdefault(k, []).append(v)
+
+            # Overwrite old forestry data
+            container_obj = CONTAINERS.get(t)
+            setattr(stand, t, container_obj().vectorize(attr_dict))
+
+    return stands
+
+
+__all__ = ["vectorize"]
+
+if __name__ == "__main__":
+    stands = [ForestStand(reference_trees=[ReferenceTree(species=1), ReferenceTree(species=2)])]
+    vectorize(stands)
+    print()

--- a/lukefi/metsi/data/vectorize.py
+++ b/lukefi/metsi/data/vectorize.py
@@ -5,7 +5,6 @@ import numpy as np
 import numpy.typing as npt
 from lukefi.metsi.data.enums.internal import TreeSpecies
 from lukefi.metsi.data.model import ForestStand, ReferenceTree
-from lukefi.metsi.domain.forestry_types import StandList
 
 
 DTYPE_TREE = np.dtype([

--- a/lukefi/metsi/data/vectorize.py
+++ b/lukefi/metsi/data/vectorize.py
@@ -1,67 +1,65 @@
-from dataclasses import dataclass
 from typing import Optional, Any
 import numpy as np
 import numpy.typing as npt
 from lukefi.metsi.data.model import ForestStand
 
 
-DTYPE_TREE = np.dtype([
-    ("identifier", "U20"),
-    ("tree_number", np.int32),
-    ("species", np.int32),
-    ("breast_height_diameter", np.float64),
-    ("height", np.float64),
-    ("measured_height", np.float64),
-    ("breast_height_age", np.float64),
-    ("biological_age", np.float64),
-    ("stems_per_ha", np.float64),
-    ("origin", np.int32),
-    ("management_category", np.int32),
-    ("saw_log_volume_reduction_factor", np.float64),
-    ("pruning_year", np.int16),
-    ("age_when_10cm_diameter_at_breast_height", np.int16),
-    ("stand_origin_relative_position", np.float64, (3,)),
-    ("lowest_living_branch_height", np.float64),
-    ("tree_category", np.str_),
-    ("storey", np.int32),
-    ("sapling", np.bool_),
-    ("tree_type", "U20"),
-    ("tuhon_ilmiasu", "U20"),
-    ("latvuskerros", np.float64)  # NOTE: for benchmarking purposes
-])
+DTYPES_TREE: dict[str, npt.DTypeLike] = {
+    "identifier": np.dtype("U20"),
+    "tree_number": np.int32,
+    "species": np.int32,
+    "breast_height_diameter": np.float64,
+    "height": np.float64,
+    "measured_height": np.float64,
+    "breast_height_age": np.float64,
+    "biological_age": np.float64,
+    "stems_per_ha": np.float64,
+    "origin": np.int32,
+    "management_category": np.int32,
+    "saw_log_volume_reduction_factor": np.float64,
+    "pruning_year": np.int16,
+    "age_when_10cm_diameter_at_breast_height": np.int16,
+    "stand_origin_relative_position": np.dtype((np.float64, (3,))),
+    "lowest_living_branch_height": np.float64,
+    "tree_category": np.str_,
+    "storey": np.int32,
+    "sapling": np.bool_,
+    "tree_type": np.dtype("U20"),
+    "tuhon_ilmiasu": np.dtype("U20"),
+    "latvuskerros": np.float64  # NOTE: for benchmarking purposes
+}
 
-DTYPE_STRATA = np.dtype([
-    ("identifier", "U20"),
-    ("species", np.int32),
-    ("mean_diameter", np.float64),
-    ("mean_height", np.float64),
-    ("breast_height_age", np.float64),
-    ("biological_age", np.int32),
-    ("stems_per_ha", np.float64),
-    ("basal_area", np.float64),
-    ("origin", np.int32),
-    ("management_category", np.int32),
-    ("saw_log_volume_reduction_factor", np.float64),
-    ("cutting_year", np.int32),
-    ("age_when_10cm_diameter_at_breast_height", np.int16),
-    ("tree_number", np.int32),
-    ("stand_origin_relative_position", np.float64, (3,)),
-    ("lowest_living_branch_height", np.float64),
-    ("storey", np.int32),
-    ("sapling_stems_per_ha", np.float64),
-    ("sapling_stratum", np.bool_),
-    ("number_of_generated_trees", np.int32)
-])
+DTYPES_STRATA: dict[str, npt.DTypeLike] = {
+    "identifier": np.dtype("U20"),
+    "species": np.int32,
+    "mean_diameter": np.float64,
+    "mean_height": np.float64,
+    "breast_height_age": np.float64,
+    "biological_age": np.int32,
+    "stems_per_ha": np.float64,
+    "basal_area": np.float64,
+    "origin": np.int32,
+    "management_category": np.int32,
+    "saw_log_volume_reduction_factor": np.float64,
+    "cutting_year": np.int32,
+    "age_when_10cm_diameter_at_breast_height": np.int16,
+    "tree_number": np.int32,
+    "stand_origin_relative_position": np.dtype((np.float64, (3,))),
+    "lowest_living_branch_height": np.float64,
+    "storey": np.int32,
+    "sapling_stems_per_ha": np.float64,
+    "sapling_stratum": np.bool_,
+    "number_of_generated_trees": np.int32
+}
 
 
-@dataclass
 class VectorData():
-    def __init__(self, dtype):
-        self.dtype = dtype
+    def __init__(self, dtypes: dict[str, npt.DTypeLike]):
+        self.dtypes = dtypes
 
     def vectorize(self, attr_dict):
         for k, v in attr_dict.items():
-            setattr(self, k, np.array(self.defaultify(v, self.dtype[k]), self.dtype[k]))
+            setattr(self, k, np.array(self.defaultify(v, self.dtypes[k]), self.dtypes[k]))
             if not self.is_contiguous(k):
                 raise Exception("Vectorized data is not contiguous")
         self.set_size(attr_dict)
@@ -105,18 +103,60 @@ class VectorData():
         return value
 
 
-@dataclass
 class ReferenceTrees(VectorData):
 
+    identifier: npt.NDArray[np.str_]
+    tree_number: npt.NDArray[np.int32]
+    species: npt.NDArray[np.int32]
+    breast_height_diameter: npt.NDArray[np.float64]
+    height: npt.NDArray[np.float64]
+    measured_height: npt.NDArray[np.float64]
+    breast_height_age: npt.NDArray[np.float64]
+    biological_age: npt.NDArray[np.float64]
+    stems_per_ha: npt.NDArray[np.float64]
+    origin: npt.NDArray[np.int32]
+    management_category: npt.NDArray[np.int32]
+    saw_log_volume_reduction_factor: npt.NDArray[np.float64]
+    pruning_year: npt.NDArray[np.int16]
+    age_when_10cm_diameter_at_breast_height: npt.NDArray[np.int16]
+    stand_origin_relative_position: npt.NDArray[np.float64]
+    lowest_living_branch_height: npt.NDArray[np.float64]
+    tree_category: npt.NDArray[np.str_]
+    storey: npt.NDArray[np.int32]
+    sapling: npt.NDArray[np.bool_]
+    tree_type: npt.NDArray[np.str_]
+    tuhon_ilmiasu: npt.NDArray[np.str_]
+    latvuskerros: npt.NDArray[np.float64]
+
     def __init__(self):
-        super().__init__(DTYPE_TREE)
+        super().__init__(DTYPES_TREE)
 
 
-@dataclass
 class Strata(VectorData):
 
+    identifier: npt.NDArray[np.str_]
+    species: npt.NDArray[np.int32]
+    mean_diameter: npt.NDArray[np.float64]
+    mean_height: npt.NDArray[np.float64]
+    breast_height_age: npt.NDArray[np.float64]
+    biological_age: npt.NDArray[np.int32]
+    stems_per_ha: npt.NDArray[np.float64]
+    basal_area: npt.NDArray[np.float64]
+    origin: npt.NDArray[np.int32]
+    management_category: npt.NDArray[np.int32]
+    saw_log_volume_reduction_factor: npt.NDArray[np.float64]
+    cutting_year: npt.NDArray[np.int32]
+    age_when_10cm_diameter_at_breast_height: npt.NDArray[np.int16]
+    tree_number: npt.NDArray[np.int32]
+    stand_origin_relative_position: npt.NDArray[np.float64]
+    lowest_living_branch_height: npt.NDArray[np.float64]
+    storey: npt.NDArray[np.int32]
+    sapling_stems_per_ha: npt.NDArray[np.float64]
+    sapling_stratum: npt.NDArray[np.bool_]
+    number_of_generated_trees: npt.NDArray[np.int32]
+
     def __init__(self):
-        super().__init__(DTYPE_STRATA)
+        super().__init__(DTYPES_STRATA)
 
 
 CONTAINERS = {
@@ -126,6 +166,21 @@ CONTAINERS = {
 
 
 def vectorize(stands: list[ForestStand], **operation_params) -> list[ForestStand]:
+    """
+    Modifies a list of ForestStand objects' reference_trees and tree_strata into a struct-of-arrays style.
+    The lists of ReferenceTree and TreeStratum are converted into ReferenceTrees and Strata with numpy arrays for
+    each attribute.
+    
+    Note that this should be the default representation in the future and the conversion from array-of-structs
+    should no longer be necessary.
+    
+    Args:
+        stands (list[ForestStand]): List of ForestStand objects in standard AoS format
+
+    Returns:
+        list[ForestStand]: A reference to the same list is returned after the objects are modified in-place
+    """
+    
     target = operation_params.get('target', None)
     if target is None:
         target = ['reference_trees', 'tree_strata']

--- a/lukefi/metsi/data/vectorize.py
+++ b/lukefi/metsi/data/vectorize.py
@@ -1,10 +1,8 @@
 from dataclasses import dataclass
 from typing import Optional, Any
-from pprint import pprint
 import numpy as np
 import numpy.typing as npt
-from lukefi.metsi.data.enums.internal import TreeSpecies
-from lukefi.metsi.data.model import ForestStand, ReferenceTree
+from lukefi.metsi.data.model import ForestStand
 
 
 DTYPE_TREE = np.dtype([

--- a/lukefi/metsi/domain/pre_ops.py
+++ b/lukefi/metsi/domain/pre_ops.py
@@ -10,6 +10,7 @@ from lukefi.metsi.forestry.preprocessing.age_supplementing import supplement_age
 from lukefi.metsi.forestry.preprocessing.naslund import naslund_height
 from lukefi.metsi.forestry.preprocessing.tree_generation_validation import create_stratum_tree_comparison_set, \
     debug_output_row_from_comparison_set, debug_output_header_row
+from lukefi.metsi.data.vectorize import vectorize
 
 
 def preproc_filter(stands: list[ForestStand], **operation_params) -> list[ForestStand]:
@@ -216,4 +217,5 @@ __all__ = ['preproc_filter',
            'supplement_missing_stratum_diameters',
            'generate_sapling_trees_from_sapling_strata',
            'scale_area_weight',
-           'convert_coordinates']
+           'convert_coordinates',
+           'vectorize']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "lukefi.metsi"
 description = "Metsi forestry simulator."
-version = "2.0.4"
+version = "2.1.0"
 readme = "README.md"
 requires-python = ">=3.10"
 authors = [

--- a/tests/app/file_io_test.py
+++ b/tests/app/file_io_test.py
@@ -4,7 +4,6 @@ import shutil
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 from dataclasses import dataclass
-import numpy as np
 from lukefi.metsi.app import file_io
 from lukefi.metsi.data.enums.internal import (
     DrainageCategory, LandUseCategory, OwnerCategory, SiteType, SoilPeatlandCategory, Storey, TreeSpecies)
@@ -82,6 +81,9 @@ class TestFileReading(unittest.TestCase):
         data = [[
             Test(a=1),
             Test(a=2)
+        ], [
+            Test(a=3),
+            Test(a=4)
         ]]
         ec = ExportableContainer(export_objects=data, additional_vars=None)
 

--- a/tests/app/file_io_test.py
+++ b/tests/app/file_io_test.py
@@ -3,10 +3,11 @@ import os
 import shutil
 from pathlib import Path
 from unittest.mock import patch, MagicMock
-from importlib.util import spec_from_file_location, module_from_spec
-from lukefi.metsi.data.enums.internal import *
-from lukefi.metsi.app import file_io
 from dataclasses import dataclass
+import numpy as np
+from lukefi.metsi.app import file_io
+from lukefi.metsi.data.enums.internal import (
+    DrainageCategory, LandUseCategory, OwnerCategory, SiteType, SoilPeatlandCategory, Storey, TreeSpecies)
 from lukefi.metsi.data.model import ForestStand, ReferenceTree, TreeStratum
 from lukefi.metsi.app.app_types import ExportableContainer
 
@@ -29,7 +30,7 @@ class TestFileReading(unittest.TestCase):
         ]
         for a in assertions:
             result = file_io.determine_file_path(*a[0])
-            self.assertEqual(a[1], result) 
+            self.assertEqual(a[1], result)
 
     def test_file_contents(self):
         input_file_path = os.path.join(os.getcwd(), "tests", "resources", "file_io_test", "test_dummy")
@@ -41,8 +42,9 @@ class TestFileReading(unittest.TestCase):
             Test(a=1),
             Test(a=2)
         ]
+        ec = ExportableContainer(export_objects=data, additional_vars=None)
         file_io.prepare_target_directory('outdir')
-        file_io.pickle_writer(Path('outdir', 'output.pickle'), data)
+        file_io.pickle_writer(Path('outdir', 'output.pickle'), ec)
         result = file_io.pickle_reader('outdir/output.pickle')
         self.assertListEqual(data, result)
         os.remove('outdir/output.pickle')
@@ -62,6 +64,34 @@ class TestFileReading(unittest.TestCase):
         os.remove('outdir/output.json')
         shutil.rmtree('outdir')
 
+    def test_npy(self):
+        data = [
+            Test(a=1),
+            Test(a=2)
+        ]
+        ec = ExportableContainer(export_objects=data, additional_vars=None)
+
+        file_io.prepare_target_directory('outdir')
+        file_io.npy_writer(Path('outdir', 'output.npy'), ec)
+        result = file_io.npy_file_reader('outdir/output.npy')
+        self.assertListEqual(data, result.tolist())
+        os.remove('outdir/output.npy')
+        shutil.rmtree('outdir')
+
+    def test_npz(self):
+        data = [[
+            Test(a=1),
+            Test(a=2)
+        ]]
+        ec = ExportableContainer(export_objects=data, additional_vars=None)
+
+        file_io.prepare_target_directory('outdir')
+        file_io.npz_writer(Path('outdir', 'output.npz'), ec)
+        result = file_io.npz_file_reader('outdir/output.npz')
+        self.assertListEqual(data, [subresult.tolist() for subresult in result])
+        os.remove('outdir/output.npz')
+        shutil.rmtree('outdir')
+
     def test_csv(self):
         data = [
             ForestStand(
@@ -76,7 +106,7 @@ class TestFileReading(unittest.TestCase):
             )
         ]
         ec = ExportableContainer(export_objects=data, additional_vars=None)
-        
+
         file_io.prepare_target_directory("outdir")
         file_io.csv_writer(Path("outdir", "output.csv"), ec)
         result = file_io.csv_content_to_stands(
@@ -117,7 +147,7 @@ class TestFileReading(unittest.TestCase):
         target = Path("outdir", "output.rst")
         file_io.rst_writer(target, ec)
 
-        #There is no rst input so check sanity just by file existence and non-emptiness
+        # There is no rst input so check sanity just by file existence and non-emptiness
         exists = os.path.exists(target)
         size = os.path.getsize(target)
         self.assertTrue(exists)
@@ -165,7 +195,6 @@ class TestFileReading(unittest.TestCase):
         self.assertTrue(exists)
         self.assertTrue(size > 0)
         shutil.rmtree('outdir')
-
 
     def test_read_stands_from_pickle_file(self):
         config = MetsiConfiguration(
@@ -237,14 +266,14 @@ class TestFileReading(unittest.TestCase):
         self.assertEqual(len(stands), 9)
 
     def test_read_schedule_payload_from_directory(self):
-        dir = Path("tests/resources/file_io_test/testing_output_directory/3/0")
-        result = file_io.read_schedule_payload_from_directory(dir)
+        dir_ = Path("tests/resources/file_io_test/testing_output_directory/3/0")
+        result = file_io.read_schedule_payload_from_directory(dir_)
         self.assertEqual("3", result.computational_unit.identifier)
         self.assertEqual(2, len(result.collected_data.get_list_result("calculate_biomass")))
 
     def test_read_simulation_result_dirtree(self):
-        dir = Path("tests/resources/file_io_test/testing_output_directory")
-        result = file_io.read_full_simulation_result_dirtree(dir)
+        dir_ = Path("tests/resources/file_io_test/testing_output_directory")
+        result = file_io.read_full_simulation_result_dirtree(dir_)
         self.assertEqual(1, len(result.items()))
         self.assertEqual(1, len(result["3"]))
         self.assertEqual("3", result["3"][0].computational_unit.identifier)
@@ -284,7 +313,7 @@ class TestReadControlModule(unittest.TestCase):
 
     def test_read_control_module_attribute_error(self):
         control_path = os.path.join(os.getcwd(), "tests", "resources", "file_io_test", "dummy_control.py")
-        with open(control_path, "w") as f:
+        with open(control_path, "w", encoding="utf-8") as f:
             f.write("some_variable = {'key': 'value'}")  # Create a dummy control file without the expected attribute
 
         with self.assertRaises(AttributeError) as context:

--- a/tests/data/vectorize_test.py
+++ b/tests/data/vectorize_test.py
@@ -1,0 +1,46 @@
+import copy
+import unittest
+
+from lukefi.metsi.data.vectorize import ReferenceTrees, Strata, vectorize
+from lukefi.metsi.data.enums.internal import TreeSpecies
+from lukefi.metsi.data.model import ForestStand, ReferenceTree, TreeStratum
+
+
+class TestVectorize(unittest.TestCase):
+
+    before: list[ForestStand]
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.before = [ForestStand(reference_trees=[ReferenceTree(species=TreeSpecies(1)),
+                                                   ReferenceTree(species=TreeSpecies(2))]),
+                      ForestStand(reference_trees=[ReferenceTree(species=TreeSpecies(3)),
+                                                   ReferenceTree(species=TreeSpecies(4))],
+                                  tree_strata=[TreeStratum(species=TreeSpecies(1)),
+                                               TreeStratum(species=TreeSpecies(2))]),
+                      ForestStand(tree_strata=[TreeStratum(species=TreeSpecies(3)),
+                                               TreeStratum(species=TreeSpecies(4))])]
+
+    def setUp(self) -> None:
+        self.after = copy.deepcopy(TestVectorize.before)
+        vectorize(self.after)
+
+    def test_types(self):
+        self.assertIsInstance(TestVectorize.before[0].reference_trees, list)
+        self.assertIsInstance(TestVectorize.before[0].tree_strata, list)
+        self.assertIsInstance(self.after[0].reference_trees, ReferenceTrees)
+        self.assertIsInstance(self.after[0].tree_strata, Strata)
+
+    def test_lengths(self):
+        self.assertEqual(len(self.after), len(TestVectorize.before))
+
+    def test_species(self):
+        self.assertEqual(TestVectorize.before[0].reference_trees[0].species.value,
+                             self.after[0].reference_trees.species[0])
+        for before, after in zip(TestVectorize.before, self.after):
+            for aso_tree, soa_tree_species in zip(before.reference_trees, after.reference_trees.species if
+                                after.reference_trees.size > 0 else []):
+                self.assertEqual(aso_tree.species, soa_tree_species)
+            for aso_stratum, soa_stratum_species in zip(before.tree_strata, after.tree_strata.species if
+                                after.tree_strata.size > 0 else []):
+                self.assertEqual(aso_stratum.species, soa_stratum_species)

--- a/tests/data/vectorize_test.py
+++ b/tests/data/vectorize_test.py
@@ -1,6 +1,8 @@
 import copy
 import unittest
 
+import numpy as np
+
 from lukefi.metsi.data.vectorize import ReferenceTrees, Strata, vectorize
 from lukefi.metsi.data.enums.internal import TreeSpecies
 from lukefi.metsi.data.model import ForestStand, ReferenceTree, TreeStratum
@@ -30,6 +32,8 @@ class TestVectorize(unittest.TestCase):
         self.assertIsInstance(TestVectorize.before[0].tree_strata, list)
         self.assertIsInstance(self.after[0].reference_trees, ReferenceTrees)
         self.assertIsInstance(self.after[0].tree_strata, Strata)
+        self.assertIsInstance(self.after[0].reference_trees.species, np.ndarray)
+        self.assertIsInstance(self.after[1].tree_strata.species, np.ndarray)
 
     def test_lengths(self):
         self.assertEqual(len(self.after), len(TestVectorize.before))


### PR DESCRIPTION
### Added 'vectorize' pre-processing operation
- Converts list of ForestStand objects into a single ForestStands object with numpy arrays for members (SoA)

### Added 'npy' and 'npz' export_prepro formats
- Can output vectorized data to numpy binary formats
- Pickle can also be used for output

### Added 'control_vector.py' to examples
- Demonstrates pre-processing from VMI13 format into vectorized data and outputs with pickle, npy and npz