### PR TITLE
ci, test: generate and publish code coverage data, #MELA2-41

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -54,7 +54,7 @@ jobs:
 
     - name: Test with pytest
       run: |
-        python -m pytest --junit-xml=pytest.xml --cov=lukefi --cov-report xml
+        python -m pytest --junit-xml=pytest.xml --cov=lukefi --cov-report xml --cov-branch
       
     - name: Run Robot Tests
       run: |
@@ -108,3 +108,11 @@ jobs:
         uses: irongut/CodeCoverageSummary@v1.3.0
         with:
           filename: artifacts/**/coverage.xml
+          format: markdown
+          output: both
+          badge: true
+          fail_below_min: true
+          hide_complexity: true
+          hide_branch_rate: false
+          indicators: true
+          thresholds: '60 80'

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -116,3 +116,10 @@ jobs:
           hide_branch_rate: false
           indicators: true
           thresholds: '60 80'
+
+      - name: Add Coverage PR Comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        if: github.event_name == 'pull_request'
+        with:
+          recreate: true
+          path: code-coverage-results.md

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -121,5 +121,4 @@ jobs:
         uses: marocchino/sticky-pull-request-comment@v2
         if: github.event_name == 'pull_request'
         with:
-          recreate: true
           path: code-coverage-results.md

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -54,7 +54,7 @@ jobs:
 
     - name: Test with pytest
       run: |
-        python -m pytest --junit-xml=pytest.xml
+        python -m pytest --junit-xml=pytest.xml --cov=lukefi --cov-report xml
       
     - name: Run Robot Tests
       run: |
@@ -67,6 +67,7 @@ jobs:
       with:
         name: Test Results (Python ${{ matrix.python-version }}, R ${{ matrix.r-version}})
         path: |
+          coverage.xml
           pytest.xml
           log.html
           report.html
@@ -102,3 +103,8 @@ jobs:
           files: |
             artifacts/**/pytest.xml
             artifacts/**/robottest.xml
+
+      - name: Code Coverage Report
+        uses: irongut/CodeCoverageSummary@v1.3.0
+        with:
+          filename: artifacts/**/coverage.xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-tests = ["pytest", "parameterized==0.9.0", "robotframework==7.3"]
+tests = ["pytest", "pytest-cov", "parameterized==0.9.0", "robotframework==7.3"]
 
 [project.scripts]
 metsi = "lukefi.metsi.app.metsi:main"


### PR DESCRIPTION
### Add unit test coverage report as PR comment
- Added line and branch coverage reporting to pytest run
- Added pipeline actions to process the coverage data and post a summary on the PR