### PR TITLE
Fix: Deletes old target filese MELA2-48

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2.1.1] - 2025-06-27
+
+### Fixed
+
+- Deletes old target files before creating new ones. #MELA2-48
+
 ## [2.1.0] - 2025-06-24
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "lukefi.metsi"
 description = "Metsi forestry simulator."
-version = "2.1.0"
+version = "2.1.1"
 readme = "README.md"
 requires-python = ">=3.10"
 authors = [


### PR DESCRIPTION
Fix: Old target files from target folder needs to be deleted before creating new ones. This change will look for target files named in given control file and tries to delete them before simulation. New simulation will always append to target files after MELA2-45.  