### PR TITLE
An example of the transition functionality

### DIFF
--- a/control.py
+++ b/control.py
@@ -10,7 +10,7 @@ control_structure = {
         # "state_input_container": "csv",  # Only relevant with fdm state_format. Options: pickle, json
         # "state_output_container": "csv",  # options: pickle, json, csv, null
         # "derived_data_output_container": "pickle",  # options: pickle, json, null
-        "formation_strategy": "partial",
+        "formation_strategy": "full",
         "evaluation_strategy": "depth",
         "run_modes": ["preprocess", "export_prepro", "simulate", "postprocess", "export"]
     },
@@ -38,6 +38,10 @@ control_structure = {
             }
         ]
     },
+    "transition": {
+        "start_year": 2018,
+        "operation": grow_acta,
+    },
     "simulation_events": [
         {
             "time_points": [2020],
@@ -46,7 +50,7 @@ control_structure = {
             ]
         },
         {
-            "time_points": [2020, 2025, 2030, 2035, 2040, 2045, 2050],
+            "time_points": [2020, 2023, 2030, 2035, 2040, 2045, 2050], 
             "generators": [
                 {sequence: [
                     cross_cut_standing_trees,
@@ -94,13 +98,6 @@ control_structure = {
             "time_points": [2050],
             "generators": [
                 {sequence: [report_collectives]}
-            ]
-        },
-        {
-            "time_points": [2020, 2025, 2030, 2035, 2040, 2045, 2050],
-            "generators": [
-                {sequence: [grow_acta]}
-                # "grow_motti"
             ]
         }
     ],

--- a/lukefi/metsi/domain/natural_processes/grow_acta.py
+++ b/lukefi/metsi/domain/natural_processes/grow_acta.py
@@ -13,6 +13,7 @@ def split_sapling_trees(trees: list[ReferenceTree]) -> tuple[list[ReferenceTree]
 
 def grow_acta(input_: tuple[ForestStand, None], /, **operation_parameters) -> tuple[ForestStand, None]:
     step = operation_parameters.get('step', 5)
+    print("step:", step)
     stand, _ = input_
     if len(stand.reference_trees) == 0:
         return input_

--- a/lukefi/metsi/sim/core_types.py
+++ b/lukefi/metsi/sim/core_types.py
@@ -40,6 +40,7 @@ class SimConfiguration(SimpleNamespace):
     events: list[DeclaredEvents] = []
     run_constraints: dict[str, dict] = {}
     time_points = []
+    transition: dict[str, Callable | int] = {}
 
     def __init__(self, **kwargs):
         """


### PR DESCRIPTION
Just to get hang of the feature #MELA2-35. Here is a initial example of the transition functionality.

In this solution one declares a transition operation to be used to transit the time between simulation events. Also the simulation starting year (mimics the source data starting year) is defined in config so we can update the source data to the simulation starting year (Ajantasaistus).

The example solution manipulates the generator declaration data structure by adding the `grow_acta` operation as first index of the generator set declared for time point.

Note that the example is enabled only with the current control.py setups strategy and evaluator. In other words it only works for:
```
"app_configuration": {
        "formation_strategy": "full",
        "evaluation_strategy": "depth",
```