### PR TITLE
chore: add .coveragerc with tests folder omitted

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+omit =
+    tests/*


### PR DESCRIPTION
Added a config file for pycov. Currently only tests are omitted from coverage analysis, which is already explicitly done by the pipeline invocation, but can be helpful for local runs. It is also easy to add new omit statements in the future - modules like MetsiGrow, for example, that are taken mostly as-is and without comprehensive tests.