### PR TITLE
fix: state output default values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [3.2.3] - 2025-09-23
+
+### Fixed
+
+- Default values for vectorized data now output as 'None' for csv export
+- Changed biological_age datatype to float64
+
 ## [3.2.2] - 2025-09-22
 
 ### Fixed

--- a/lukefi/metsi/data/formats/io_utils.py
+++ b/lukefi/metsi/data/formats/io_utils.py
@@ -119,7 +119,7 @@ def rsts_forest_stand_rows(stand: PossiblyLayered[ForestStand]) -> list[str]:
 
 
 def csv_value(source: Any) -> str:
-    if source is None:
+    if source in ("-1", "nan", "", None):
         return "None"
     return str(source)
 

--- a/lukefi/metsi/data/vector_model.py
+++ b/lukefi/metsi/data/vector_model.py
@@ -35,7 +35,7 @@ DTYPES_STRATA: dict[str, npt.DTypeLike] = {
     "mean_diameter": np.float64,
     "mean_height": np.float64,
     "breast_height_age": np.float64,
-    "biological_age": np.int32,
+    "biological_age": np.float64,
     "stems_per_ha": np.float64,
     "basal_area": np.float64,
     "origin": np.int32,
@@ -295,7 +295,7 @@ class Strata(VectorData):
     mean_diameter: npt.NDArray[np.float64]
     mean_height: npt.NDArray[np.float64]
     breast_height_age: npt.NDArray[np.float64]
-    biological_age: npt.NDArray[np.int32]
+    biological_age: npt.NDArray[np.float64]
     stems_per_ha: npt.NDArray[np.float64]
     basal_area: npt.NDArray[np.float64]
     origin: npt.NDArray[np.int32]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "lukefi.metsi"
 description = "Metsi forestry simulator."
-version = "3.2.2"
+version = "3.2.3"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [


### PR DESCRIPTION
Outputting vectorized data to csv now maps default values to "None" to match output from non-vectorized data.